### PR TITLE
refactor: remove built-in extractor filtering

### DIFF
--- a/LeanScout/DataExtractors/ConstDep.lean
+++ b/LeanScout/DataExtractors/ConstDep.lean
@@ -14,24 +14,25 @@ public unsafe def constDep : DataExtractor where
     { name := "name", nullable := false, type := .string },
     { name := "module", nullable := true, type := .string },
     { name := "deps", nullable := false, type := .list .string },
+    { name := "allowCompletion", nullable := false, type := .bool },
   ]
   key := "name"
   go config sink opts
   | .imports tgt => do
-    let cfg ← match parseFilterTaskLimitConfig "const_dep" config with
+    let cfg ← match parseTaskLimitConfig "const_dep" config with
       | .ok cfg => pure cfg
       | .error err => throw <| IO.userError err
     tgt.runParallelCoreM opts (maxTasks := cfg.taskLimit) fun env n c => Meta.MetaM.run' do
-      if cfg.filter && (← declNameFilter n) then return
       let mod : Option Name := match env.getModuleIdxFor? n with
         | some idx => env.header.moduleNames[idx]!
         | none => if env.constants.map₂.contains n then env.header.mainModule else none
-      let deps : Array String ← c.getUsedConstantsAsSet.toArray |>.filterMapM fun nm => do
-        if cfg.filter && (← declNameFilter nm) then return none else return nm.toString
+      let deps : Array String := c.getUsedConstantsAsSet.toArray.map fun nm => nm.toString
+      let allowCompletion := Lean.Meta.allowCompletion env n
       sink <| json% {
         name : $(n),
         module : $(mod),
-        deps : $(deps)
+        deps : $(deps),
+        allowCompletion : $(allowCompletion)
       }
   | _ => throw <| IO.userError "Unsupported Target"
 

--- a/LeanScout/DataExtractors/Tactics.lean
+++ b/LeanScout/DataExtractors/Tactics.lean
@@ -23,15 +23,14 @@ public unsafe def tactics : DataExtractor where
   key := "ppTac"
   go config sink opts
   | .input tgt => do
-    let cfg ← match parseFilterConfig "tactics" config with
-      | .ok cfg => pure cfg
-      | .error err => throw <| IO.userError err
+    match parseEmptyConfig "tactics" config with
+    | .ok () => pure ()
+    | .error err => throw <| IO.userError err
     discard <| tgt.withVisitM opts (α := Unit) (ctx? := none)
       (fun _ _ _ => return true) fun ctxInfo info _ _ => ctxInfo.runMetaM' {} do
         let .ofTacticInfo info := info | return
         let some (.original ..) := info.stx.getHeadInfo? | return
         let kind := info.stx.getKind
-        if cfg.filter && tacFilter.contains kind then return
         let ppTac : String := toString info.stx.prettyPrint
         let elaborator := info.elaborator
         let goals : List Json ← info.goalsBefore.mapM fun mvarId =>

--- a/LeanScout/DataExtractors/Types.lean
+++ b/LeanScout/DataExtractors/Types.lean
@@ -14,22 +14,24 @@ public unsafe def types : DataExtractor where
     { name := "name", nullable := false, type := .string },
     { name := "module", nullable := true, type := .string },
     { name := "type", nullable := false, type := .string },
+    { name := "allowCompletion", nullable := false, type := .bool },
   ]
   key := "name"
   go config sink opts
   | .imports tgt => do
-    let cfg ← match parseFilterTaskLimitConfig "types" config with
+    let cfg ← match parseTaskLimitConfig "types" config with
       | .ok cfg => pure cfg
       | .error err => throw <| IO.userError err
     tgt.runParallelCoreM opts (maxTasks := cfg.taskLimit) fun env n c => Meta.MetaM.run' do
-      if cfg.filter && (← declNameFilter n) then return
       let mod : Option Name := match env.getModuleIdxFor? n with
         | some idx => env.header.moduleNames[idx]!
         | none => if env.constants.map₂.contains n then env.header.mainModule else none
+      let allowCompletion := Lean.Meta.allowCompletion env n
       sink <| json% {
         name : $(n),
         module : $(mod),
-        type : $(s!"{← Meta.ppExpr c.type}")
+        type : $(s!"{← Meta.ppExpr c.type}"),
+        allowCompletion : $(allowCompletion)
       }
   | _ => throw <| IO.userError "Unsupported Target"
 

--- a/LeanScout/DataExtractors/Utils.lean
+++ b/LeanScout/DataExtractors/Utils.lean
@@ -10,11 +10,7 @@ namespace DataExtractors
 
 abbrev ConfigObj := Std.TreeMap.Raw String Json compare
 
-structure FilterConfig where
-  filter : Bool := false
-
-structure FilterTaskLimitConfig where
-  filter : Bool := false
+structure TaskLimitConfig where
   taskLimit : Option Nat := none
 
 private def getConfigObj (extractorName : String) (config : Json) : Except String ConfigObj :=
@@ -40,72 +36,17 @@ private def getOptionalField [FromJson α]
       | .error err =>
           throw s!"Invalid config for extractor '{extractorName}', field '{field}': {err}"
 
-public def parseFilterConfig (extractorName : String) (config : Json) : Except String FilterConfig := do
+public def parseEmptyConfig (extractorName : String) (config : Json) : Except String Unit := do
   let obj ← getConfigObj extractorName config
-  rejectUnknownKeys extractorName obj ["filter"]
-  return {
-    filter := (← getOptionalField extractorName obj "filter").getD false
-  }
+  rejectUnknownKeys extractorName obj []
 
-public def parseFilterTaskLimitConfig
-    (extractorName : String) (config : Json) : Except String FilterTaskLimitConfig := do
+public def parseTaskLimitConfig
+    (extractorName : String) (config : Json) : Except String TaskLimitConfig := do
   let obj ← getConfigObj extractorName config
-  rejectUnknownKeys extractorName obj ["filter", "taskLimit"]
+  rejectUnknownKeys extractorName obj ["taskLimit"]
   return {
-    filter := (← getOptionalField extractorName obj "filter").getD false
     taskLimit := ← getOptionalField extractorName obj "taskLimit"
   }
-
--- A more aggressive variant of Lean's own completion blacklist.
---
--- We start from `Lean.Meta.allowCompletion`, but close the predicate under
--- prefixes so that descendants of filtered declarations are filtered as well
--- (e.g. `Nat.brecOn.eq`, `...match_3.congr_eq_2`). We also keep a small set of
--- project-specific exclusions that Lean does not blacklist for completion.
-private def isExtraFilteredLeaf : Name → Bool
-  | .str _ s =>
-      s == "inj" ||
-      s == "injEq" ||
-      s == "sizeOf_spec" ||
-      s == "toCtorIdx"
-  | _ => false
-
-private def hasFilteredNamespace (declName : Name) : Bool :=
-  declName.components.contains `Grind || declName.components.contains `Omega
-
-private def anyPrefix (declName : Name) (p : Name → Bool) : Bool :=
-  p declName || match declName with
-    | .anonymous => false
-    | .str pre _ => anyPrefix pre p
-    | .num pre _ => anyPrefix pre p
-
-def declNameFilterCore (env : Environment) (declName : Name) : Bool :=
-  hasFilteredNamespace declName ||
-  anyPrefix declName fun n =>
-    n == ``sorryAx ||
-    n.isInternalDetail ||
-    isPrivateName n ||
-    !Lean.Meta.allowCompletion env n ||
-    isExtraFilteredLeaf n
-
-def declNameFilter {m} [Monad m] [MonadEnv m] (declName : Name) : m Bool := do
-  return declNameFilterCore (← getEnv) declName
-
-def tacFilter : Lean.SyntaxNodeKinds := [
-  `Lean.Parser.Term.byTactic,
-  `Lean.Parser.Tactic.tacticSeq,
-  `Lean.Parser.Tactic.tacticSeq1Indented,
-  `Lean.Parser.Tactic.withAnnotateState,
-  `Lean.cdotTk,
-  `Lean.cdot,
-  `ident,
-  `«by»,
-  `«;»,
-  `«<;>»,
-  `«{»,
-  `«]»,
-  Lean.nullKind,
-]
 
 end DataExtractors
 end LeanScout

--- a/LeanScoutTest.lean
+++ b/LeanScoutTest.lean
@@ -24,23 +24,23 @@ def schemaRoundtrip (schema : Schema) : IO Unit := do
   println! "\n"
   println! (← c.stdout.readToEnd).trimAscii
 
-open LeanScout.DataExtractors in
-def declNameFilterRegressionTest : IO Unit := do
+def allowCompletionRegressionTest : IO Unit := do
   initSearchPath (← Lean.findSysroot)
   let env ← importModules #[{ module := `Lean }] {} 0
   let cases : Array (Name × Bool) := #[
-    (`OfScientific.ctorIdx, true),
+    (`OfScientific.ctorIdx, false),
+    (`Nat.rec, false),
+    (`Nat.noConfusion, false),
     (`Nat.brecOn.eq, true),
-    (`Std.DTreeMap.Internal.Impl.balanceL!.match_3.congr_eq_2, true),
-    (`List.map, false),
-    (`Nat.add, false)
+    (`List.map, true),
+    (`Nat.add, true)
   ]
   for (declName, expected) in cases do
-    let actual := declNameFilterCore env declName
+    let actual := Lean.Meta.allowCompletion env declName
     unless actual == expected do
-      throw <| IO.userError s!"declNameFilterCore {declName}: expected {expected}, got {actual}"
+      throw <| IO.userError s!"allowCompletion {declName}: expected {expected}, got {actual}"
 
-#eval declNameFilterRegressionTest
+#eval allowCompletionRegressionTest
 
 /--
 info:

--- a/README.md
+++ b/README.md
@@ -189,28 +189,36 @@ Lean Scout supports multiple extraction modes:
 Extractors can be configured using the `--config` flag, which accepts a JSON object:
 
 ```bash
-lake run scout --config '{"filter": true}' --command types --parquet --imports Lean
+lake run scout --config '{"taskLimit": 8}' --command types --parquet --imports Lean
 ```
 
+### Filtering philosophy
+
+Built-in extractors do **not** filter data during extraction.
+Instead, they emit enough metadata for users to filter downstream in whatever way matches their use case.
+
+In other words:
+- extraction should preserve the raw data
+- built-in extractors should expose useful filter metadata
+- filtering policy belongs to downstream consumers, not the extraction step
+
 Built-in extractors validate config strictly. Unknown keys and values of the wrong type are treated as extraction errors and cause a nonzero exit code.
+
+**Breaking change**: built-in `filter` config is no longer supported. Filtering should now be done downstream using emitted metadata such as `allowCompletion` and `kind`.
 
 ### Available Configuration Options
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `filter` | boolean | `false` | When `true`, filters out internal/auto-generated declarations (for `types` / `const_dep`) or common tactic syntax nodes (for `tactics`) |
 | `taskLimit` | natural number | unset | Maximum number of concurrent per-constant worker tasks for imports-mode extractors (`types`, `const_dep`) |
 
 **Examples**:
 ```bash
-# Enable filtering to exclude internal declarations
-lake run scout --config '{"filter": true}' --command types --parquet --imports Lean
-
-# Bound imports-mode worker parallelism
+# Bound imports-mode worker parallelism for imports-mode extractors
 lake run scout --config '{"taskLimit": 8}' --command const_dep --parquet --imports Lean
 
-# Disable filtering to get all tactic nodes (default behavior)
-lake run scout --config '{"filter": false}' --command tactics --parquet --library MyLib
+# Tactics accepts an empty config only; filter downstream on `kind`
+lake run scout --command tactics --parquet --library MyLib
 ```
 
 ## Sharding
@@ -240,10 +248,15 @@ lake run scout --command types --parquet --imports Lean
 - `name` (string): Constant name
 - `module` (string, nullable): Module containing the constant
 - `type` (string): Type signature
+- `allowCompletion` (bool): Whether `Lean.Meta.allowCompletion` holds for the constant
 
 **Configuration**:
-- `filter` (default: `false`): When `true`, excludes internal declarations like recursors, `noConfusion`, matchers, and other auto-generated constants
 - `taskLimit` (optional natural number): Bounds concurrent per-constant worker tasks during imports-mode extraction
+
+**Downstream filtering example**:
+```python
+filtered = dataset.filter(lambda x: x["allowCompletion"])
+```
 
 ### `tactics`
 Extracts tactic invocations with goal states, used constants, elaborator info, and syntax kinds.
@@ -264,7 +277,12 @@ lake run scout --command tactics --parquet --parallel 4 --library LeanScoutTest
 - `kind` (string): Non-null syntax node kind for the tactic
 
 **Configuration**:
-- `filter` (default: `false`): When `true`, excludes common structural tactic nodes like `byTactic`, `tacticSeq`, identifiers, and punctuation
+- no built-in extractor-specific options; config must be `{}`
+
+**Downstream filtering example**:
+```python
+structural = dataset.filter(lambda x: x["kind"] == "Lean.Parser.Tactic.tacticSeq")
+```
 
 ### `const_dep`
 Extracts constant dependency information, mapping each constant to the set of constants it uses.
@@ -280,10 +298,16 @@ lake run scout --command const_dep --parquet --imports Lean
 - `name` (string): Constant name
 - `module` (string, nullable): Module containing the constant
 - `deps` (list of strings): Names of constants directly used by this constant
+- `allowCompletion` (bool): Whether `Lean.Meta.allowCompletion` holds for the parent constant
 
 **Configuration**:
-- `filter` (default: `false`): When `true`, excludes internal declarations (recursors, matchers, `noConfusion`, etc.) from both the extracted constants and their dependency lists
 - `taskLimit` (optional natural number): Bounds concurrent per-constant worker tasks during imports-mode extraction
+
+**Downstream filtering example**:
+```python
+filtered_rows = dataset.filter(lambda x: x["allowCompletion"])
+# If you need dependency-level metadata, join dependency names against `types` output.
+```
 
 ## Creating datasets
 

--- a/test/extractors/test_const_dep.py
+++ b/test/extractors/test_const_dep.py
@@ -88,6 +88,12 @@ def test_const_dep_imports_properties(const_dep_dataset_imports, const_dep_spec)
         if props.get('module_not_null'):
             assert_record_not_null(actual, 'module')
 
+        if 'allowCompletion' in props:
+            assert actual['allowCompletion'] == props['allowCompletion'], (
+                f"allowCompletion mismatch for {name}: "
+                f"expected {props['allowCompletion']}, got {actual['allowCompletion']}"
+            )
+
         if 'deps_contains' in props:
             dep = props['deps_contains']
             assert dep in actual['deps'], (
@@ -131,10 +137,12 @@ def test_const_dep_imports_schema(const_dep_dataset_imports):
     assert 'name' in first_record
     assert 'module' in first_record
     assert 'deps' in first_record
+    assert 'allowCompletion' in first_record
 
     assert isinstance(first_record['name'], str)
     assert first_record['module'] is None or isinstance(first_record['module'], str)
     assert isinstance(first_record['deps'], list)
+    assert isinstance(first_record['allowCompletion'], bool)
     for dep in first_record['deps']:
         assert isinstance(dep, str)
 
@@ -187,8 +195,10 @@ def test_const_dep_jsonl_output_format(const_dep_jsonl_records):
     for record in const_dep_jsonl_records:
         assert "name" in record, "Record should have 'name' field"
         assert "deps" in record, "Record should have 'deps' field"
+        assert "allowCompletion" in record, "Record should have 'allowCompletion' field"
         assert isinstance(record["name"], str)
         assert isinstance(record["deps"], list)
+        assert isinstance(record["allowCompletion"], bool)
 
 
 def test_const_dep_jsonl_has_expected_records(const_dep_jsonl_records):
@@ -206,9 +216,16 @@ def test_const_dep_jsonl_record_content(const_dep_jsonl_records):
     assert add_comm is not None, "Should find add_comm record"
 
     assert add_comm["module"] == "LeanScoutTestProject.Basic"
+    assert add_comm["allowCompletion"] is True
     # add_comm should have dependencies on Nat lemmas
     assert "Nat.zero_add" in add_comm["deps"]
     assert "Nat.add_zero" in add_comm["deps"]
+
+
+def test_const_dep_known_non_completion_record(const_dep_dataset_imports):
+    record = get_record_by_name(const_dep_dataset_imports, "OfScientific.ctorIdx")
+    assert record is not None, "Should find OfScientific.ctorIdx record"
+    assert record["allowCompletion"] is False
 
 
 def test_const_dep_jsonl_no_output_directory_created():

--- a/test/extractors/test_tactics.py
+++ b/test/extractors/test_tactics.py
@@ -131,6 +131,13 @@ def test_tactics_dataset_record_schema(tactics_dataset):
     assert isinstance(first_record['kind'], str)
 
 
+def test_tactics_includes_structural_kinds(tactics_dataset):
+    kinds = set(tactics_dataset['kind'])
+
+    assert 'Lean.Parser.Term.byTactic' in kinds
+    assert 'Lean.Parser.Tactic.tacticSeq' in kinds
+
+
 def test_tactics_induction(tactics_dataset):
     induction_records = get_records_by_tactic_contains(tactics_dataset, "induction")
 

--- a/test/extractors/test_types.py
+++ b/test/extractors/test_types.py
@@ -98,6 +98,12 @@ def test_types_imports_properties(types_dataset_imports, types_spec):
         if props.get('module_not_null'):
             assert_record_not_null(actual, 'module')
 
+        if 'allowCompletion' in props:
+            assert actual['allowCompletion'] == props['allowCompletion'], (
+                f"allowCompletion mismatch for {name}: "
+                f"expected {props['allowCompletion']}, got {actual['allowCompletion']}"
+            )
+
 
 def test_types_imports_count_min_records(types_dataset_imports, types_spec):
     counts = types_spec['count_checks']
@@ -128,10 +134,12 @@ def test_types_imports_schema(types_dataset_imports):
     assert 'name' in first_record
     assert 'module' in first_record
     assert 'type' in first_record
+    assert 'allowCompletion' in first_record
 
     assert isinstance(first_record['name'], str)
     assert first_record['module'] is None or isinstance(first_record['module'], str)
     assert isinstance(first_record['type'], str)
+    assert isinstance(first_record['allowCompletion'], bool)
 
 
 def test_types_imports_modules(types_dataset_imports):
@@ -183,8 +191,10 @@ def test_types_jsonl_output_format(types_jsonl_records):
     for record in types_jsonl_records:
         assert "name" in record, "Record should have 'name' field"
         assert "type" in record, "Record should have 'type' field"
+        assert "allowCompletion" in record, "Record should have 'allowCompletion' field"
         assert isinstance(record["name"], str)
         assert isinstance(record["type"], str)
+        assert isinstance(record["allowCompletion"], bool)
 
 
 def test_types_jsonl_has_expected_records(types_jsonl_records):
@@ -203,6 +213,13 @@ def test_types_jsonl_record_content(types_jsonl_records):
 
     assert add_zero["module"] == "LeanScoutTestProject.Basic"
     assert "Nat" in add_zero["type"]
+    assert add_zero["allowCompletion"] is True
+
+
+def test_types_known_non_completion_record(types_dataset_imports):
+    record = get_record_by_name(types_dataset_imports, "OfScientific.ctorIdx")
+    assert record is not None, "Should find OfScientific.ctorIdx record"
+    assert record["allowCompletion"] is False
 
 
 def test_types_jsonl_no_output_directory_created():

--- a/test/fixtures/const_dep.yaml
+++ b/test/fixtures/const_dep.yaml
@@ -8,6 +8,7 @@ property_checks:
     properties:
       module: "LeanScoutTestProject.Basic"
       module_not_null: true
+      allowCompletion: true
       deps_contains_all:
         - "Nat"
         - "Eq"
@@ -16,12 +17,14 @@ property_checks:
     properties:
       module: "LeanScoutTestProject.Basic"
       module_not_null: true
+      allowCompletion: true
       deps_contains: "Nat.zero_add"
 
   - name: "add_comm"
     properties:
       module: "LeanScoutTestProject.Basic"
       module_not_null: true
+      allowCompletion: true
       deps_contains_all:
         - "Nat.zero_add"
         - "Nat.add_zero"
@@ -32,15 +35,23 @@ property_checks:
     properties:
       module: "LeanScoutTestProject.Lists"
       module_not_null: true
+      allowCompletion: true
       deps_contains: "List"
 
   - name: "list_map_nil"
     properties:
       module: "LeanScoutTestProject.Lists"
       module_not_null: true
+      allowCompletion: true
       deps_contains_all:
         - "List"
         - "List.map"
+
+  - name: "OfScientific.ctorIdx"
+    properties:
+      module: "Init.Data.OfScientific"
+      module_not_null: true
+      allowCompletion: false
 
 # Count checks: verify dataset statistics
 count_checks:

--- a/test/fixtures/types.yaml
+++ b/test/fixtures/types.yaml
@@ -42,12 +42,21 @@ property_checks:
       module_contains: "LeanScoutTestProject"
       type_contains: "Nat"
       module_not_null: true
+      allowCompletion: true
 
   - name: "list_nil_append"
     properties:
       module_contains: "LeanScoutTestProject"
       type_contains: "List"
       module_not_null: true
+      allowCompletion: true
+
+  - name: "OfScientific.ctorIdx"
+    properties:
+      module_contains: "Init.Data.OfScientific"
+      type_contains: "OfScientific"
+      module_not_null: true
+      allowCompletion: false
 
 # Count checks: verify dataset statistics
 count_checks:

--- a/test/integration/test_lean_orchestrator.sh
+++ b/test/integration/test_lean_orchestrator.sh
@@ -264,12 +264,24 @@ echo ""
 # --- Config Validation Tests ---
 echo "Config Validation:"
 
-run_test "types rejects wrong config type" \
-    "lake run scout --config '{\"filter\":\"notbool\"}' --command types --jsonl --imports LeanScoutTestProject" \
+run_test "types rejects removed filter field" \
+    "lake run scout --config '{\"filter\":true}' --command types --jsonl --imports LeanScoutTestProject" \
     1 "Invalid config"
+
+run_test "types rejects wrong taskLimit type" \
+    "lake run scout --config '{\"taskLimit\":\"notnat\"}' --command types --jsonl --imports LeanScoutTestProject" \
+    1 "Invalid config"
+
+run_test "const_dep accepts taskLimit config" \
+    "lake run scout --config '{\"taskLimit\":1}' --command const_dep --jsonl --imports LeanScoutTestProject" \
+    0 ""
 
 run_test "const_dep rejects wrong taskLimit type" \
     "lake run scout --config '{\"taskLimit\":\"notnat\"}' --command const_dep --jsonl --imports LeanScoutTestProject" \
+    1 "Invalid config"
+
+run_test "tactics rejects removed filter field" \
+    "lake run scout --config '{\"filter\":true}' --command tactics --jsonl --read LeanScoutTestProject/Basic.lean" \
     1 "Invalid config"
 
 run_test "tactics rejects unknown config fields" \


### PR DESCRIPTION
## Summary
- remove built-in extractor-side filtering from `types`, `const_dep`, and `tactics`
- add downstream filter metadata to built-in outputs (`allowCompletion` for imports-mode extractors, existing `kind` for tactics)
- remove built-in `filter` config support and keep only strict empty/taskLimit configs as appropriate
- update README and tests for the new downstream-filtering philosophy

## Breaking changes
- built-in `filter` config is no longer supported
- `types` now includes `allowCompletion : bool`
- `const_dep` now includes top-level `allowCompletion : bool`
- `tactics` still emits `kind` and now always emits unfiltered built-in output

## Validation
- `lake build`
- `lake test` (runs the full project suite here, including Python, integration, and extractor tests)
