### PR TITLE
fix: align read-mode frontend defaults with Lean CLI

### DIFF
--- a/LeanScout/Frontend.lean
+++ b/LeanScout/Frontend.lean
@@ -25,9 +25,14 @@ private unsafe def throwIfMessagesHaveErrors
 
 namespace InputTarget
 
+private def applyCmdlineFrontendDefaults (opts : Options) : Options :=
+  let opts := Lean.internal.cmdlineSnapshots.setIfNotSet opts true
+  Elab.async.setIfNotSet opts true
+
 unsafe def processCommands (tgt : InputTarget) (opts : Options) (go : State → IO α) : IO α := do
   initSearchPath (← findSysroot)
   enableInitializersExecution
+  let opts := applyCmdlineFrontendDefaults opts
   let inputCtx ← tgt.inputCtx
   let (header, parserState, messages) ← Parser.parseHeader inputCtx
   throwIfMessagesHaveErrors tgt.path "parsing" messages

--- a/LeanScoutTest/InputFrontendRegression.lean
+++ b/LeanScoutTest/InputFrontendRegression.lean
@@ -1,0 +1,25 @@
+/-
+Regression fixture for Lean Scout's input-mode frontend.
+
+Historically, Lean Scout's manual frontend in `--read` mode diverged from
+`lake env lean` and failed on this file with:
+
+  Unknown identifier `privateWitness`
+
+The failure required a module file using `@[expose] public section`,
+`backward.privateInPublic`, a private theorem, and a later public `def`
+referencing it. The final theorem provides a tactic block so the `tactics`
+extractor emits JSONL output in the integration test.
+-/
+module
+
+@[expose] public section
+
+set_option backward.privateInPublic true in
+private theorem privateWitness : True := True.intro
+
+set_option backward.privateInPublic true in
+def exportedWitness := privateWitness
+
+theorem usesExportedWitness : True := by
+  exact exportedWitness

--- a/run_tests
+++ b/run_tests
@@ -4,7 +4,7 @@ set -e  # Exit on error
 
 echo ""
 echo "╔════════════════════════════════════════════════╗"
-echo "║      Lean Scout Test Suite (Six Phases)        ║"
+echo "║     Lean Scout Test Suite (Seven Phases)       ║"
 echo "╚════════════════════════════════════════════════╝"
 
 # Sync test_project toolchain with repo root
@@ -35,6 +35,11 @@ echo ""
 echo "=== Phase 4: Lean Orchestrator Integration Tests ==="
 echo "Testing CLI argument handling and orchestration"
 ./test/integration/test_lean_orchestrator.sh
+
+echo ""
+echo "=== Phase 4b: Input Frontend Regression Test ==="
+echo "Testing --read frontend behavior against a local minimal repro"
+./test/integration/test_input_frontend_regression.sh
 
 echo ""
 echo "=== Phase 5: End-to-End Extractor Tests ==="

--- a/test/integration/test_input_frontend_regression.sh
+++ b/test/integration/test_input_frontend_regression.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+#
+# Regression test for input-mode frontend defaults using a local minimal repro.
+#
+# Historically, Lean Scout's manual frontend in `--read` mode diverged from
+# `lake env lean` and rejected `LeanScoutTest/InputFrontendRegression.lean`
+# before extractor logic ran.
+
+set -euo pipefail
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[0;33m'
+NC='\033[0m'
+
+pass() {
+  echo -e "${GREEN}✓${NC} $1"
+}
+
+fail() {
+  echo -e "${RED}✗${NC} $1"
+  if [ -n "${2:-}" ]; then
+    echo -e "${YELLOW}  Output:${NC}"
+    echo "$2" | head -40 | sed 's/^/    /'
+  fi
+  exit 1
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+WORKDIR="$(mktemp -d)"
+PLAIN_STDOUT="$WORKDIR/plain.out"
+PLAIN_STDERR="$WORKDIR/plain.err"
+SCOUT_STDOUT="$WORKDIR/scout.out"
+SCOUT_STDERR="$WORKDIR/scout.err"
+TARGET_FILE="LeanScoutTest/InputFrontendRegression.lean"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+echo "=== Input Frontend Regression Test ==="
+echo -e "${YELLOW}Repository root:${NC} $REPO_ROOT"
+echo -e "${YELLOW}Target file:${NC} $TARGET_FILE"
+echo ""
+
+echo "Checking plain Lean control..."
+set +e
+(
+  cd "$REPO_ROOT"
+  lake env lean "$TARGET_FILE" >"$PLAIN_STDOUT" 2>"$PLAIN_STDERR"
+)
+plain_exit=$?
+set -e
+if [ "$plain_exit" -ne 0 ]; then
+  fail "Plain Lean should accept $TARGET_FILE" "$(cat "$PLAIN_STDERR")"
+fi
+pass "Plain Lean accepts $TARGET_FILE"
+
+echo "Checking Lean Scout input frontend..."
+set +e
+(
+  cd "$REPO_ROOT"
+  lake run scout \
+    --command tactics \
+    --jsonl \
+    --parallel 1 \
+    --read "$TARGET_FILE" >"$SCOUT_STDOUT" 2>"$SCOUT_STDERR"
+)
+scout_exit=$?
+set -e
+if [ "$scout_exit" -ne 0 ]; then
+  fail "Lean Scout should process $TARGET_FILE in --read mode" "$(cat "$SCOUT_STDERR")"
+fi
+
+if [ ! -s "$SCOUT_STDOUT" ]; then
+  fail "Lean Scout should emit tactic records for $TARGET_FILE" "$(cat "$SCOUT_STDERR")"
+fi
+
+if ! head -n 1 "$SCOUT_STDOUT" | python3 -c 'import json, sys; json.loads(sys.stdin.read())' >/dev/null 2>&1; then
+  fail "Lean Scout should emit valid JSONL" "$(head -n 5 "$SCOUT_STDOUT")"
+fi
+pass "Lean Scout processes $TARGET_FILE and emits valid JSONL"
+
+echo ""
+echo -e "${GREEN}Input frontend regression test passed!${NC}"


### PR DESCRIPTION
## Summary
- apply Lean cmdline frontend defaults in `InputTarget.processCommands`
- add a minimal local regression fixture for the private-in-public input-mode bug
- replace the Mathlib-based regression test with the local repro in `run_tests`

## Testing
- `lake build`
- `./test/integration/test_lean_orchestrator.sh`
- `./test/integration/test_input_frontend_regression.sh`