### PR TITLE
feat: polish `tactics` data extractor

### DIFF
--- a/LeanScout/DataExtractors/Tactics.lean
+++ b/LeanScout/DataExtractors/Tactics.lean
@@ -4,10 +4,9 @@ public import LeanScout.Frontend
 public import LeanScout.InfoTree
 public import LeanScout.Init
 
-open Lean
+open Lean Meta
 
-namespace LeanScout
-namespace DataExtractors
+namespace LeanScout.DataExtractors
 
 private def positionType : DataType :=
   .struct [
@@ -19,12 +18,28 @@ private def getModuleName? (ctxInfo : Lean.Elab.ContextInfo) : Option String :=
   let moduleName := ctxInfo.env.header.mainModule
   if moduleName == .anonymous then none else some s!"{moduleName}"
 
-private def getSyntaxRange (ctxInfo : Lean.Elab.ContextInfo) (stx : Syntax) : IO (Lean.Position × Lean.Position) := do
+private structure PositionRangeWithNext where
+  startPos : Position
+  endPos : Position
+  /-- Computed by looking at where the trailing whitespace ends. Does not imply that there is a
+  next tactic; this is merely the start position of whatever syntax comes next (possibly the end of
+  the file). -/
+  nextStartPos : Position
+
+private def getSyntaxRange (ctxInfo : Lean.Elab.ContextInfo) (stx : Syntax) :
+    IO PositionRangeWithNext := do
   let some startPos := stx.getPos?
     | throw <| IO.userError s!"Original tactic syntax missing start position for '{stx.getKind}'"
   let some endPos := stx.getTailPos?
     | throw <| IO.userError s!"Original tactic syntax missing end position for '{stx.getKind}'"
-  return (ctxInfo.fileMap.toPosition startPos, ctxInfo.fileMap.toPosition endPos)
+  let some nextStartPos := stx.getTrailingTailPos?
+    | throw <| IO.userError s!"Original tactic syntax missing end position after trailing \
+      whitespace for '{stx.getKind}'"
+  return {
+    startPos := ctxInfo.fileMap.toPosition startPos,
+    endPos := ctxInfo.fileMap.toPosition endPos,
+    nextStartPos := ctxInfo.fileMap.toPosition nextStartPos
+  }
 
 @[data_extractor tactics]
 public unsafe def tactics : DataExtractor where
@@ -32,6 +47,7 @@ public unsafe def tactics : DataExtractor where
     { name := "module", type := .string },
     { name := "startPos", nullable := false, type := positionType },
     { name := "endPos", nullable := false, type := positionType },
+    { name := "nextStartPos", nullable := false, type := positionType },
     { name := "goals", nullable := false, type := .list <| .struct [
       { name := "pp", nullable := false, type := .string },
       { name := "usedConstants", nullable := false, type := .list .string }
@@ -53,7 +69,7 @@ public unsafe def tactics : DataExtractor where
         let ppTac : String := toString info.stx.prettyPrint
         let elaborator := info.elaborator
         let moduleName? := getModuleName? ctxInfo
-        let (startPos, endPos) ← getSyntaxRange ctxInfo info.stx
+        let { startPos, endPos, nextStartPos } ← getSyntaxRange ctxInfo info.stx
         -- `goalsBefore` must be pretty-printed using `mctxBefore`, but the corresponding
         -- metavariables may only be instantiable using assignments from `mctxAfter`.
         let ctxBefore : Lean.Elab.ContextInfo := { ctxInfo with mctx := info.mctxBefore }
@@ -72,14 +88,14 @@ public unsafe def tactics : DataExtractor where
             usedConstants : $(consts.toList.map fun nm => s!"{nm}")
           }
         sink <| json% {
-          module : $(moduleName?),
-          startPos : $(startPos),
-          endPos : $(endPos),
-          goals : $(goals),
-          ppTac : $(ppTac),
-          elaborator : $(elaborator),
-          kind : $(kind)
+          module : $moduleName?,
+          startPos : $startPos,
+          endPos : $endPos,
+          nextStartPos : $nextStartPos,
+          goals : $goals,
+          ppTac : $ppTac,
+          elaborator : $elaborator,
+          kind : $kind
         }
 
-end DataExtractors
-end LeanScout
+end LeanScout.DataExtractors

--- a/LeanScout/DataExtractors/Tactics.lean
+++ b/LeanScout/DataExtractors/Tactics.lean
@@ -52,6 +52,7 @@ public unsafe def tactics : DataExtractor where
       { name := "pp", nullable := false, type := .string },
       { name := "usedConstants", nullable := false, type := .list .string }
     ]},
+    { name := "goalsAfter", nullable := false, type := .list .string },
     { name := "ppTac", nullable := false, type := .string },
     { name := "elaborator", nullable := false, type := .string },
     { name := "kind", nullable := false, type := .string },
@@ -87,12 +88,15 @@ public unsafe def tactics : DataExtractor where
             pp : $(toString goal),
             usedConstants : $(consts.toList.map fun nm => s!"{nm}")
           }
+        let goalsAfter : List String ← ctxAfter.runMetaM' {} do
+          info.goalsAfter.mapM fun mvarId => return toString (← Meta.ppGoal mvarId)
         sink <| json% {
           module : $moduleName?,
           startPos : $startPos,
           endPos : $endPos,
           nextStartPos : $nextStartPos,
           goals : $goals,
+          goalsAfter : $goalsAfter,
           ppTac : $ppTac,
           elaborator : $elaborator,
           kind : $kind

--- a/LeanScout/DataExtractors/Tactics.lean
+++ b/LeanScout/DataExtractors/Tactics.lean
@@ -22,8 +22,7 @@ private structure PositionRangeWithNext where
   startPos : Position
   endPos : Position
   /-- Computed by looking at where the trailing whitespace ends. Does not imply that there is a
-  next tactic; this is merely the start position of whatever syntax comes next (possibly the end of
-  the file). -/
+  next tactic; this is merely the start position of whatever syntax comes next (possibly a command, tactic combinator, or even the end of the file). -/
   nextStartPos : Position
 
 private def getSyntaxRange (ctxInfo : Lean.Elab.ContextInfo) (stx : Syntax) :

--- a/LeanScout/DataExtractors/Tactics.lean
+++ b/LeanScout/DataExtractors/Tactics.lean
@@ -50,7 +50,9 @@ public unsafe def tactics : DataExtractor where
     { name := "nextStartPos", nullable := false, type := positionType },
     { name := "goals", nullable := false, type := .list <| .struct [
       { name := "pp", nullable := false, type := .string },
-      { name := "usedConstants", nullable := false, type := .list .string }
+      { name := "assigned", nullable := false, type := .bool },
+      { name := "usedConstants", nullable := false, type := .list .string },
+      { name := "usedFVars", nullable := false, type := .list .string },
     ]},
     { name := "goalsAfter", nullable := false, type := .list .string },
     { name := "ppTac", nullable := false, type := .string },
@@ -73,20 +75,27 @@ public unsafe def tactics : DataExtractor where
         let { startPos, endPos, nextStartPos } ← getSyntaxRange ctxInfo info.stx
         -- `goalsBefore` must be pretty-printed using `mctxBefore`, but the corresponding
         -- metavariables may only be instantiable using assignments from `mctxAfter`.
-        let ctxBefore : Lean.Elab.ContextInfo := { ctxInfo with mctx := info.mctxBefore }
-        let ctxAfter : Lean.Elab.ContextInfo := { ctxInfo with mctx := info.mctxAfter }
+        let ctxBefore : Elab.ContextInfo := { ctxInfo with mctx := info.mctxBefore }
+        let ctxAfter : Elab.ContextInfo := { ctxInfo with mctx := info.mctxAfter }
         let goals : List Json ← info.goalsBefore.mapM fun mvarId => do
-          let mvarDecl := info.mctxBefore.getDecl mvarId
-          let goal ← ctxBefore.runMetaM' {} do
-            Lean.Meta.withLCtx mvarDecl.lctx mvarDecl.localInstances do
-              Lean.Meta.ppGoal mvarId
-          let consts ← ctxAfter.runMetaM' {} do
-            Lean.Meta.withLCtx mvarDecl.lctx mvarDecl.localInstances do
-              let t ← Lean.instantiateMVars <| .mvar mvarId
-              return t.getUsedConstantsAsSet
+          let goal ← ctxBefore.runMetaM' {} do Meta.ppGoal mvarId
+          let (assigned, consts, fvars) ← ctxAfter.runMetaM' {} do
+            mvarId.withContext do
+              -- sufficient; user-facing goals will not be delayed-assigned
+              let assigned ← mvarId.isAssigned
+              let t ← instantiateMVars <| .mvar mvarId
+              let (_, { fvarIds .. }) ← t.collectFVars.run {}
+              -- Sanitize the names so their string representations are the same as in `ppGoal`.
+              let fvars ← if fvarIds.isEmpty then pure #[] else
+                let sanitizedLCtx := (← getLCtx).sanitizeNames.run' { options := (← getOptions) }
+                withLCtx' sanitizedLCtx do fvarIds.mapM fun fvarId =>
+                  return toString (← fvarId.getUserName)
+              return (assigned, t.getUsedConstantsAsSet, fvars)
           return json% {
             pp : $(toString goal),
-            usedConstants : $(consts.toList.map fun nm => s!"{nm}")
+            assigned : $assigned,
+            usedConstants : $(consts.toList.map fun nm => s!"{nm}"),
+            usedFVars : $fvars
           }
         let goalsAfter : List String ← ctxAfter.runMetaM' {} do
           info.goalsAfter.mapM fun mvarId => return toString (← Meta.ppGoal mvarId)

--- a/LeanScout/DataExtractors/Tactics.lean
+++ b/LeanScout/DataExtractors/Tactics.lean
@@ -77,7 +77,7 @@ public unsafe def tactics : DataExtractor where
         let ctxBefore : Elab.ContextInfo := { ctxInfo with mctx := info.mctxBefore }
         let ctxAfter : Elab.ContextInfo := { ctxInfo with mctx := info.mctxAfter }
         let goals : List Json ← info.goalsBefore.mapM fun mvarId => do
-          let goal ← ctxBefore.runMetaM' {} do Meta.ppGoal mvarId
+          let pp ← ctxBefore.runMetaM' {} do Meta.ppGoal mvarId
           let mvarDeclBefore := info.mctxBefore.getDecl mvarId
           let (assigned, consts, fvars) ← ctxAfter.runMetaM' {} do
             -- Use earlier context in case there was in-place modification of the local context
@@ -93,7 +93,7 @@ public unsafe def tactics : DataExtractor where
                   return toString (← fvarId.getUserName)
               return (assigned, t.getUsedConstantsAsSet, fvars)
           return json% {
-            pp : $(toString goal),
+            pp : $(toString pp),
             assigned : $assigned,
             usedConstants : $(consts.toList.map fun nm => s!"{nm}"),
             usedFVars : $fvars

--- a/LeanScout/DataExtractors/Tactics.lean
+++ b/LeanScout/DataExtractors/Tactics.lean
@@ -78,8 +78,10 @@ public unsafe def tactics : DataExtractor where
         let ctxAfter : Elab.ContextInfo := { ctxInfo with mctx := info.mctxAfter }
         let goals : List Json ← info.goalsBefore.mapM fun mvarId => do
           let goal ← ctxBefore.runMetaM' {} do Meta.ppGoal mvarId
+          let mvarDeclBefore := info.mctxBefore.getDecl mvarId
           let (assigned, consts, fvars) ← ctxAfter.runMetaM' {} do
-            mvarId.withContext do
+            -- Use earlier context in case there was in-place modification of the local context
+            withLCtx mvarDeclBefore.lctx mvarDeclBefore.localInstances do
               -- sufficient; user-facing goals will not be delayed-assigned
               let assigned ← mvarId.isAssigned
               let t ← instantiateMVars <| .mvar mvarId

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ filtered = dataset.filter(lambda x: x["allowCompletion"])
 ```
 
 ### `tactics`
-Extracts tactic invocations with goal states, used constants, elaborator info, syntax kinds, and source locations.
+Extracts tactic invocations with before/after goal states, used constants, used free variables, elaborator info, syntax kinds, and source locations.
 
 **Supported modes**: `--read`, `--library`
 
@@ -276,9 +276,15 @@ lake run scout --command tactics --parquet --parallel 4 --library LeanScoutTest
 - `endPos` (struct): End position of the tactic syntax in the source file
   - `line` (nat): 1-based line number
   - `column` (nat): 0-based column number
+- `nextStartPos` (struct): Position after the tactic's trailing whitespace; this is the start position of the next syntax in the source file, if any, or the end of the file
+  - `line` (nat): 1-based line number
+  - `column` (nat): 0-based column number
 - `goals` (list): List of goal states before the tactic
   - `pp` (string): Pretty-printed goal
-  - `usedConstants` (list of strings): Constants referenced in the goal
+  - `assigned` (bool): Whether the original goal metavariable is assigned after elaborating the tactic
+  - `usedConstants` (list of strings): Constants referenced in the instantiated goal
+  - `usedFVars` (list of strings): Free variables referenced in the instantiated goal, using the same sanitized names as the pretty-printed goal
+- `goalsAfter` (list of strings): Pretty-printed goal states after the tactic
 - `ppTac` (string): Pretty-printed tactic syntax
 - `elaborator` (string): Name of the elaborator that produced this tactic
 - `kind` (string): Syntax node kind for the tactic

--- a/test/extractors/test_tactics.py
+++ b/test/extractors/test_tactics.py
@@ -136,16 +136,20 @@ def test_tactics_dataset_record_schema(tactics_dataset):
     assert 'module' in first_record
     assert 'startPos' in first_record
     assert 'endPos' in first_record
+    assert 'nextStartPos' in first_record
     assert 'ppTac' in first_record
     assert 'goals' in first_record
+    assert 'goalsAfter' in first_record
     assert 'elaborator' in first_record
     assert 'kind' in first_record
 
     assert first_record['module'] is None or isinstance(first_record['module'], str)
     assert_position_dict(first_record['startPos'])
     assert_position_dict(first_record['endPos'])
+    assert_position_dict(first_record['nextStartPos'])
     assert isinstance(first_record['ppTac'], str)
     assert isinstance(first_record['goals'], list)
+    assert isinstance(first_record['goalsAfter'], list)
     assert isinstance(first_record['elaborator'], str)
     assert isinstance(first_record['kind'], str)
 
@@ -205,13 +209,22 @@ def test_tactics_parallel_extraction():
 
 def test_tactics_goal_structure(tactics_dataset):
     for record in tactics_dataset:
+        assert 'goalsAfter' in record, f"Tactic missing 'goalsAfter' for tactic {record['ppTac']}"
+        assert isinstance(record['goalsAfter'], list), f"goalsAfter should be list for tactic {record['ppTac']}"
+        for goal_after in record['goalsAfter']:
+            assert isinstance(goal_after, str), f"goalsAfter entries should be strings for tactic {record['ppTac']}"
+
         if len(record['goals']) > 0:
             for goal in record['goals']:
                 assert 'pp' in goal, f"Goal missing 'pp' for tactic {record['ppTac']}"
+                assert 'assigned' in goal, f"Goal missing 'assigned' for tactic {record['ppTac']}"
                 assert 'usedConstants' in goal, f"Goal missing 'usedConstants' for tactic {record['ppTac']}"
+                assert 'usedFVars' in goal, f"Goal missing 'usedFVars' for tactic {record['ppTac']}"
 
                 assert isinstance(goal['pp'], str), f"Goal 'pp' should be string for tactic {record['ppTac']}"
+                assert isinstance(goal['assigned'], bool), f"Goal 'assigned' should be bool for tactic {record['ppTac']}"
                 assert isinstance(goal['usedConstants'], list), f"Goal 'usedConstants' should be list for tactic {record['ppTac']}"
+                assert isinstance(goal['usedFVars'], list), f"Goal 'usedFVars' should be list for tactic {record['ppTac']}"
 
 
 def test_tactics_elaborator_field(tactics_dataset):
@@ -229,8 +242,12 @@ def test_tactics_location_fields(tactics_dataset):
 
         assert_position_dict(record['startPos'])
         assert_position_dict(record['endPos'])
+        assert_position_dict(record['nextStartPos'])
         assert position_tuple(record['startPos']) <= position_tuple(record['endPos']), (
             f"Expected startPos <= endPos for tactic {record['ppTac']}, got {record['startPos']} -> {record['endPos']}"
+        )
+        assert position_tuple(record['endPos']) <= position_tuple(record['nextStartPos']), (
+            f"Expected endPos <= nextStartPos for tactic {record['ppTac']}, got {record['endPos']} -> {record['nextStartPos']}"
         )
 
 
@@ -242,11 +259,12 @@ def test_tactics_known_source_spans(tactics_dataset):
             record['module'],
             (record['startPos']['line'], record['startPos']['column']),
             (record['endPos']['line'], record['endPos']['column']),
+            (record['nextStartPos']['line'], record['nextStartPos']['column']),
         )
         for record in zero_add_rw
     }
     assert zero_add_spans == {
-        ('LeanScoutTestProject.Basic', (7, 2), (7, 19))
+        ('LeanScoutTestProject.Basic', (7, 2), (7, 19), (9, 0))
     }
 
     succ_rw = get_records_by_tactic(tactics_dataset, 'rw [Nat.succ_add, Nat.add_succ, ih]')
@@ -256,12 +274,42 @@ def test_tactics_known_source_spans(tactics_dataset):
             record['module'],
             (record['startPos']['line'], record['startPos']['column']),
             (record['endPos']['line'], record['endPos']['column']),
+            (record['nextStartPos']['line'], record['nextStartPos']['column']),
         )
         for record in succ_rw
     }
     assert succ_spans == {
-        ('LeanScoutTestProject.Basic', (17, 4), (17, 39))
+        ('LeanScoutTestProject.Basic', (17, 4), (17, 39), (19, 0))
     }
+
+
+def test_tactics_goals_after_and_dependency_fields(tactics_dataset):
+    intro_records = [
+        record for record in get_records_by_tactic(tactics_dataset, "intro hp")
+        if record["kind"] == "Lean.Parser.Tactic.intro"
+    ]
+    assert len(intro_records) > 0, "Expected intro tactic from goalsAfter fixture"
+    intro = intro_records[0]
+    assert position_tuple(intro["nextStartPos"]) == (21, 2)
+    assert intro["goalsAfter"] == ["p : Prop\nhp : p\n⊢ p ∧ p"]
+
+    intro_goal = intro["goals"][0]
+    assert intro_goal["assigned"] is True
+    assert intro_goal["usedFVars"] == ["p"]
+
+    constructor_records = get_records_by_tactic(tactics_dataset, "constructor")
+    assert len(constructor_records) == 1, "Expected constructor tactic from goalsAfter fixture"
+    constructor = constructor_records[0]
+    assert position_tuple(constructor["nextStartPos"]) == (22, 2)
+    assert constructor["goalsAfter"] == [
+        "case left\np : Prop\nhp : p\n⊢ p",
+        "case right\np : Prop\nhp : p\n⊢ p",
+    ]
+
+    constructor_goal = constructor["goals"][0]
+    assert constructor_goal["assigned"] is True
+    assert "And.intro" in constructor_goal["usedConstants"]
+    assert constructor_goal["usedFVars"] == ["p"]
 
 
 def test_tactics_rfl_from_test_project(tactics_dataset):
@@ -311,15 +359,22 @@ def test_tactics_jsonl_output_format(tactics_jsonl_records):
         assert "module" in record, "Tactic record should have 'module' field"
         assert "startPos" in record, "Tactic record should have 'startPos' field"
         assert "endPos" in record, "Tactic record should have 'endPos' field"
+        assert "nextStartPos" in record, "Tactic record should have 'nextStartPos' field"
         assert "ppTac" in record, "Tactic record should have 'ppTac' field"
         assert "goals" in record, "Tactic record should have 'goals' field"
+        assert "goalsAfter" in record, "Tactic record should have 'goalsAfter' field"
         assert "kind" in record, "Tactic record should have 'kind' field"
         assert isinstance(record["module"], str), "Library extraction should populate module"
         assert len(record["module"]) > 0, "Module should not be empty"
         assert_position_dict(record["startPos"])
         assert_position_dict(record["endPos"])
+        assert_position_dict(record["nextStartPos"])
+        assert isinstance(record["goalsAfter"], list), "goalsAfter should be a list"
         assert position_tuple(record["startPos"]) <= position_tuple(record["endPos"]), (
             f"Expected startPos <= endPos for tactic {record['ppTac']}, got {record['startPos']} -> {record['endPos']}"
+        )
+        assert position_tuple(record["endPos"]) <= position_tuple(record["nextStartPos"]), (
+            f"Expected endPos <= nextStartPos for tactic {record['ppTac']}, got {record['endPos']} -> {record['nextStartPos']}"
         )
 
 
@@ -329,12 +384,13 @@ def test_tactics_jsonl_known_source_spans(tactics_jsonl_records):
             record["module"],
             (record["startPos"]["line"], record["startPos"]["column"]),
             (record["endPos"]["line"], record["endPos"]["column"]),
+            (record["nextStartPos"]["line"], record["nextStartPos"]["column"]),
         )
         for record in tactics_jsonl_records
         if record["ppTac"] == "rw [Nat.zero_add]"
     }
     assert zero_add_spans == {
-        ("LeanScoutTestProject.Basic", (7, 2), (7, 19))
+        ("LeanScoutTestProject.Basic", (7, 2), (7, 19), (9, 0))
     }
 
     succ_spans = {
@@ -342,12 +398,13 @@ def test_tactics_jsonl_known_source_spans(tactics_jsonl_records):
             record["module"],
             (record["startPos"]["line"], record["startPos"]["column"]),
             (record["endPos"]["line"], record["endPos"]["column"]),
+            (record["nextStartPos"]["line"], record["nextStartPos"]["column"]),
         )
         for record in tactics_jsonl_records
         if record["ppTac"] == "rw [Nat.succ_add, Nat.add_succ, ih]"
     }
     assert succ_spans == {
-        ("LeanScoutTestProject.Basic", (17, 4), (17, 39))
+        ("LeanScoutTestProject.Basic", (17, 4), (17, 39), (19, 0))
     }
 
 

--- a/test_project/LeanScoutTestProject/Basic.lean
+++ b/test_project/LeanScoutTestProject/Basic.lean
@@ -15,3 +15,9 @@ theorem add_comm (a b : Nat) : a + b = b + a := by
     rw [Nat.zero_add, Nat.add_zero]
   | succ n ih =>
     rw [Nat.succ_add, Nat.add_succ, ih]
+
+theorem tactic_goals_after_fixture (p : Prop) : p → p ∧ p := by
+  intro hp
+  constructor
+  · exact hp
+  · exact hp


### PR DESCRIPTION
This PR does the following:
- adds a `nextStartPos` field which uses the end position of trailing whitespace, allowing users to match up the end of one tactic with the beginning of another (with some exceptions)
- adds a simple `goalsAfter` field that just pretty-prints the resulting goals
- to each `goal`, adds an `assigned : Bool` field as well as a `usedFVars` field. The `usedFVars` field uses the same names that are used in the pretty-printed version of the goal (including numeric superscripts and tombstones for inaccessibles).

This also cleans up a bit of the code, and in particular modifies some local context handling. `Meta.ppGoal` sets the local context + instances to those of the goal itself, so we don't need the surrounding `withLCtx`.

Bit worried about `assigned` being interpreted as "solved", when the thing it's assigned to may have metavariables. `progress` isn't necessarily true either, if the goal is effectively the same.