### PR TITLE
feat(`tactics`): `usedGoals` for each (assigned) goal

### DIFF
--- a/LeanScout/DataExtractors/Tactics.lean
+++ b/LeanScout/DataExtractors/Tactics.lean
@@ -4,10 +4,9 @@ public import LeanScout.Frontend
 public import LeanScout.InfoTree
 public import LeanScout.Init
 
-open Lean
+open Lean Meta
 
-namespace LeanScout
-namespace DataExtractors
+namespace LeanScout.DataExtractors
 
 private def positionType : DataType :=
   .struct [
@@ -19,12 +18,28 @@ private def getModuleName? (ctxInfo : Lean.Elab.ContextInfo) : Option String :=
   let moduleName := ctxInfo.env.header.mainModule
   if moduleName == .anonymous then none else some s!"{moduleName}"
 
-private def getSyntaxRange (ctxInfo : Lean.Elab.ContextInfo) (stx : Syntax) : IO (Lean.Position × Lean.Position) := do
+private structure PositionRangeWithNext where
+  startPos : Position
+  endPos : Position
+  /-- Computed by looking at where the trailing whitespace ends. Does not imply that there is a
+  next tactic; this is merely the start position of whatever syntax comes next (possibly the end of
+  the file). -/
+  nextStartPos : Position
+
+private def getSyntaxRange (ctxInfo : Lean.Elab.ContextInfo) (stx : Syntax) :
+    IO PositionRangeWithNext := do
   let some startPos := stx.getPos?
     | throw <| IO.userError s!"Original tactic syntax missing start position for '{stx.getKind}'"
   let some endPos := stx.getTailPos?
     | throw <| IO.userError s!"Original tactic syntax missing end position for '{stx.getKind}'"
-  return (ctxInfo.fileMap.toPosition startPos, ctxInfo.fileMap.toPosition endPos)
+  let some nextStartPos := stx.getTrailingTailPos?
+    | throw <| IO.userError s!"Original tactic syntax missing end position after trailing \
+      whitespace for '{stx.getKind}'"
+  return {
+    startPos := ctxInfo.fileMap.toPosition startPos,
+    endPos := ctxInfo.fileMap.toPosition endPos,
+    nextStartPos := ctxInfo.fileMap.toPosition nextStartPos
+  }
 
 @[data_extractor tactics]
 public unsafe def tactics : DataExtractor where
@@ -32,6 +47,7 @@ public unsafe def tactics : DataExtractor where
     { name := "module", type := .string },
     { name := "startPos", nullable := false, type := positionType },
     { name := "endPos", nullable := false, type := positionType },
+    { name := "nextStartPos", nullable := false, type := positionType },
     { name := "goals", nullable := false, type := .list <| .struct [
       { name := "pp", nullable := false, type := .string },
       { name := "usedConstants", nullable := false, type := .list .string }
@@ -53,7 +69,7 @@ public unsafe def tactics : DataExtractor where
         let ppTac : String := toString info.stx.prettyPrint
         let elaborator := info.elaborator
         let moduleName? := getModuleName? ctxInfo
-        let (startPos, endPos) ← getSyntaxRange ctxInfo info.stx
+        let { startPos, endPos, nextStartPos } ← getSyntaxRange ctxInfo info.stx
         -- `goalsBefore` must be pretty-printed using `mctxBefore`, but the corresponding
         -- metavariables may only be instantiable using assignments from `mctxAfter`.
         let ctxBefore : Lean.Elab.ContextInfo := { ctxInfo with mctx := info.mctxBefore }
@@ -72,14 +88,14 @@ public unsafe def tactics : DataExtractor where
             usedConstants : $(consts.toList.map fun nm => s!"{nm}")
           }
         sink <| json% {
-          module : $(moduleName?),
-          startPos : $(startPos),
-          endPos : $(endPos),
-          goals : $(goals),
-          ppTac : $(ppTac),
-          elaborator : $(elaborator),
-          kind : $(kind)
+          module : $moduleName?,
+          startPos : $startPos,
+          endPos : $endPos,
+          nextStartPos : $nextStartPos,
+          goals : $goals,
+          ppTac : $ppTac,
+          elaborator : $elaborator,
+          kind : $kind
         }
 
-end DataExtractors
-end LeanScout
+end LeanScout.DataExtractors

--- a/LeanScout/DataExtractors/Tactics.lean
+++ b/LeanScout/DataExtractors/Tactics.lean
@@ -32,7 +32,7 @@ private partial def collectMVarsAndUsedConstants (e : Expr) (consts : NameSet) :
   return consts
 
 /-- Gets the unassigned metavariables in `e` after following delayed assignments, as well as the
-constants encountered along the way. -/
+constants encountered along the way. Does not include the intermediate delayed-assigned mvars. -/
 def getMVarsAndConstantsNoDelayed (e : Expr) : MetaM (Array MVarId × NameSet) := do
   let (consts, { result .. }) ← collectMVarsAndUsedConstants e {} |>.run {}
   let result ← result.filterM (notM ·.isDelayedAssigned)

--- a/LeanScout/DataExtractors/Tactics.lean
+++ b/LeanScout/DataExtractors/Tactics.lean
@@ -52,6 +52,7 @@ public unsafe def tactics : DataExtractor where
       { name := "pp", nullable := false, type := .string },
       { name := "usedConstants", nullable := false, type := .list .string }
     ]},
+    { name := "goalsAfter", nullable := false, type := .list .string },
     { name := "ppTac", nullable := false, type := .string },
     { name := "elaborator", nullable := false, type := .string },
     { name := "kind", nullable := false, type := .string },
@@ -87,12 +88,15 @@ public unsafe def tactics : DataExtractor where
             pp : $(toString goal),
             usedConstants : $(consts.toList.map fun nm => s!"{nm}")
           }
+        let goalsAfter : List String ← ctxAfter.runMetaM' {} do
+          info.goalsAfter.mapM fun mvarId => return toString (← Meta.ppGoal mvarId)
         sink <| json% {
           module : $moduleName?,
           startPos : $startPos,
           endPos : $endPos,
           nextStartPos : $nextStartPos,
           goals : $goals,
+          goalsAfter : $goalsAfter,
           ppTac : $ppTac,
           elaborator : $elaborator,
           kind : $kind

--- a/LeanScout/DataExtractors/Tactics.lean
+++ b/LeanScout/DataExtractors/Tactics.lean
@@ -22,8 +22,7 @@ private structure PositionRangeWithNext where
   startPos : Position
   endPos : Position
   /-- Computed by looking at where the trailing whitespace ends. Does not imply that there is a
-  next tactic; this is merely the start position of whatever syntax comes next (possibly the end of
-  the file). -/
+  next tactic; this is merely the start position of whatever syntax comes next (possibly a command, tactic combinator, or even the end of the file). -/
   nextStartPos : Position
 
 private def getSyntaxRange (ctxInfo : Lean.Elab.ContextInfo) (stx : Syntax) :

--- a/LeanScout/DataExtractors/Tactics.lean
+++ b/LeanScout/DataExtractors/Tactics.lean
@@ -50,7 +50,9 @@ public unsafe def tactics : DataExtractor where
     { name := "nextStartPos", nullable := false, type := positionType },
     { name := "goals", nullable := false, type := .list <| .struct [
       { name := "pp", nullable := false, type := .string },
-      { name := "usedConstants", nullable := false, type := .list .string }
+      { name := "assigned", nullable := false, type := .bool },
+      { name := "usedConstants", nullable := false, type := .list .string },
+      { name := "usedFVars", nullable := false, type := .list .string },
     ]},
     { name := "goalsAfter", nullable := false, type := .list .string },
     { name := "ppTac", nullable := false, type := .string },
@@ -73,20 +75,27 @@ public unsafe def tactics : DataExtractor where
         let { startPos, endPos, nextStartPos } ← getSyntaxRange ctxInfo info.stx
         -- `goalsBefore` must be pretty-printed using `mctxBefore`, but the corresponding
         -- metavariables may only be instantiable using assignments from `mctxAfter`.
-        let ctxBefore : Lean.Elab.ContextInfo := { ctxInfo with mctx := info.mctxBefore }
-        let ctxAfter : Lean.Elab.ContextInfo := { ctxInfo with mctx := info.mctxAfter }
+        let ctxBefore : Elab.ContextInfo := { ctxInfo with mctx := info.mctxBefore }
+        let ctxAfter : Elab.ContextInfo := { ctxInfo with mctx := info.mctxAfter }
         let goals : List Json ← info.goalsBefore.mapM fun mvarId => do
-          let mvarDecl := info.mctxBefore.getDecl mvarId
-          let goal ← ctxBefore.runMetaM' {} do
-            Lean.Meta.withLCtx mvarDecl.lctx mvarDecl.localInstances do
-              Lean.Meta.ppGoal mvarId
-          let consts ← ctxAfter.runMetaM' {} do
-            Lean.Meta.withLCtx mvarDecl.lctx mvarDecl.localInstances do
-              let t ← Lean.instantiateMVars <| .mvar mvarId
-              return t.getUsedConstantsAsSet
+          let goal ← ctxBefore.runMetaM' {} do Meta.ppGoal mvarId
+          let (assigned, consts, fvars) ← ctxAfter.runMetaM' {} do
+            mvarId.withContext do
+              -- sufficient; user-facing goals will not be delayed-assigned
+              let assigned ← mvarId.isAssigned
+              let t ← instantiateMVars <| .mvar mvarId
+              let (_, { fvarIds .. }) ← t.collectFVars.run {}
+              -- Sanitize the names so their string representations are the same as in `ppGoal`.
+              let fvars ← if fvarIds.isEmpty then pure #[] else
+                let sanitizedLCtx := (← getLCtx).sanitizeNames.run' { options := (← getOptions) }
+                withLCtx' sanitizedLCtx do fvarIds.mapM fun fvarId =>
+                  return toString (← fvarId.getUserName)
+              return (assigned, t.getUsedConstantsAsSet, fvars)
           return json% {
             pp : $(toString goal),
-            usedConstants : $(consts.toList.map fun nm => s!"{nm}")
+            assigned : $assigned,
+            usedConstants : $(consts.toList.map fun nm => s!"{nm}"),
+            usedFVars : $fvars
           }
         let goalsAfter : List String ← ctxAfter.runMetaM' {} do
           info.goalsAfter.mapM fun mvarId => return toString (← Meta.ppGoal mvarId)

--- a/LeanScout/DataExtractors/Tactics.lean
+++ b/LeanScout/DataExtractors/Tactics.lean
@@ -77,7 +77,7 @@ public unsafe def tactics : DataExtractor where
         let ctxBefore : Elab.ContextInfo := { ctxInfo with mctx := info.mctxBefore }
         let ctxAfter : Elab.ContextInfo := { ctxInfo with mctx := info.mctxAfter }
         let goals : List Json ← info.goalsBefore.mapM fun mvarId => do
-          let goal ← ctxBefore.runMetaM' {} do Meta.ppGoal mvarId
+          let pp ← ctxBefore.runMetaM' {} do Meta.ppGoal mvarId
           let mvarDeclBefore := info.mctxBefore.getDecl mvarId
           let (assigned, consts, fvars) ← ctxAfter.runMetaM' {} do
             -- Use earlier context in case there was in-place modification of the local context
@@ -93,7 +93,7 @@ public unsafe def tactics : DataExtractor where
                   return toString (← fvarId.getUserName)
               return (assigned, t.getUsedConstantsAsSet, fvars)
           return json% {
-            pp : $(toString goal),
+            pp : $(toString pp),
             assigned : $assigned,
             usedConstants : $(consts.toList.map fun nm => s!"{nm}"),
             usedFVars : $fvars

--- a/LeanScout/DataExtractors/Tactics.lean
+++ b/LeanScout/DataExtractors/Tactics.lean
@@ -78,8 +78,10 @@ public unsafe def tactics : DataExtractor where
         let ctxAfter : Elab.ContextInfo := { ctxInfo with mctx := info.mctxAfter }
         let goals : List Json ← info.goalsBefore.mapM fun mvarId => do
           let goal ← ctxBefore.runMetaM' {} do Meta.ppGoal mvarId
+          let mvarDeclBefore := info.mctxBefore.getDecl mvarId
           let (assigned, consts, fvars) ← ctxAfter.runMetaM' {} do
-            mvarId.withContext do
+            -- Use earlier context in case there was in-place modification of the local context
+            withLCtx mvarDeclBefore.lctx mvarDeclBefore.localInstances do
               -- sufficient; user-facing goals will not be delayed-assigned
               let assigned ← mvarId.isAssigned
               let t ← instantiateMVars <| .mvar mvarId

--- a/LeanScout/DataExtractors/Tactics.lean
+++ b/LeanScout/DataExtractors/Tactics.lean
@@ -14,6 +14,30 @@ private def positionType : DataType :=
     { name := "column", nullable := false, type := .nat }
   ]
 
+/--
+Like `Meta.collectMVars`, but also collects used constants after following delayed assignments.
+-/
+private partial def collectMVarsAndUsedConstants (e : Expr) (consts : NameSet) :
+    StateRefT CollectMVars.State MetaM NameSet := do
+  let e ← instantiateMVars e
+  let s ← get
+  let resultSavedSize := s.result.size
+  let mut consts := e.getUsedConstantsAsSet ∪ consts
+  let s := e.collectMVars s
+  set s
+  for mvarId in s.result[resultSavedSize...*] do
+    match (← getDelayedMVarAssignment? mvarId) with
+    | none   => pure ()
+    | some d => consts ← collectMVarsAndUsedConstants (.mvar d.mvarIdPending) consts
+  return consts
+
+/-- Gets the unassigned metavariables in `e` after following delayed assignments, as well as the
+constants encountered along the way. -/
+def getMVarsAndConstantsNoDelayed (e : Expr) : MetaM (Array MVarId × NameSet) := do
+  let (consts, { result .. }) ← collectMVarsAndUsedConstants e {} |>.run {}
+  let result ← result.filterM (notM ·.isDelayedAssigned)
+  return (result, consts)
+
 private def getModuleName? (ctxInfo : Lean.Elab.ContextInfo) : Option String :=
   let moduleName := ctxInfo.env.header.mainModule
   if moduleName == .anonymous then none else some s!"{moduleName}"
@@ -40,6 +64,12 @@ private def getSyntaxRange (ctxInfo : Lean.Elab.ContextInfo) (stx : Syntax) :
     nextStartPos := ctxInfo.fileMap.toPosition nextStartPos
   }
 
+local instance : ToString MetavarKind where
+  toString
+    | .natural => "natural"
+    | .synthetic => "synthetic"
+    | .syntheticOpaque => "syntheticOpaque"
+
 @[data_extractor tactics]
 public unsafe def tactics : DataExtractor where
   schema := .mk [
@@ -52,6 +82,12 @@ public unsafe def tactics : DataExtractor where
       { name := "assigned", nullable := false, type := .bool },
       { name := "usedConstants", nullable := false, type := .list .string },
       { name := "usedFVars", nullable := false, type := .list .string },
+      { name := "usedGoals", nullable := false, type := .list <| .struct [
+        { name := "new", nullable := false, type := .bool },
+        { name := "index", nullable := true, type := .nat }, -- null ↔ does not appear in goal list
+        { name := "kind", nullable := false, type := .string },
+        { name := "pp", nullable := false, type := .string }
+      ]}
     ]},
     { name := "goalsAfter", nullable := false, type := .list .string },
     { name := "ppTac", nullable := false, type := .string },
@@ -79,7 +115,7 @@ public unsafe def tactics : DataExtractor where
         let goals : List Json ← info.goalsBefore.mapM fun mvarId => do
           let pp ← ctxBefore.runMetaM' {} do Meta.ppGoal mvarId
           let mvarDeclBefore := info.mctxBefore.getDecl mvarId
-          let (assigned, consts, fvars) ← ctxAfter.runMetaM' {} do
+          let (assigned, consts, fvars, usedGoals) ← ctxAfter.runMetaM' {} do
             -- Use earlier context in case there was in-place modification of the local context
             withLCtx mvarDeclBefore.lctx mvarDeclBefore.localInstances do
               -- sufficient; user-facing goals will not be delayed-assigned
@@ -91,12 +127,25 @@ public unsafe def tactics : DataExtractor where
                 let sanitizedLCtx := (← getLCtx).sanitizeNames.run' { options := (← getOptions) }
                 withLCtx' sanitizedLCtx do fvarIds.mapM fun fvarId =>
                   return toString (← fvarId.getUserName)
-              return (assigned, t.getUsedConstantsAsSet, fvars)
+              let (mvars, consts) ← getMVarsAndConstantsNoDelayed t
+              let usedGoals : Array Json ← mvars.mapM fun mvarId => do
+                let new := !info.mctxBefore.decls.contains mvarId
+                let index? := info.goalsAfter.idxOf? mvarId
+                let kind ← mvarId.getKind
+                let pp ← Meta.ppGoal mvarId
+                return json% {
+                  new : $new,
+                  index : $index?,
+                  kind : $(toString kind),
+                  pp : $(toString pp)
+                }
+              return (assigned, consts, fvars, usedGoals)
           return json% {
             pp : $(toString pp),
             assigned : $assigned,
             usedConstants : $(consts.toList.map fun nm => s!"{nm}"),
-            usedFVars : $fvars
+            usedFVars : $fvars,
+            usedGoals : $usedGoals
           }
         let goalsAfter : List String ← ctxAfter.runMetaM' {} do
           info.goalsAfter.mapM fun mvarId => return toString (← Meta.ppGoal mvarId)

--- a/LeanScout/DataExtractors/Tactics.lean
+++ b/LeanScout/DataExtractors/Tactics.lean
@@ -127,18 +127,20 @@ public unsafe def tactics : DataExtractor where
                 let sanitizedLCtx := (← getLCtx).sanitizeNames.run' { options := (← getOptions) }
                 withLCtx' sanitizedLCtx do fvarIds.mapM fun fvarId =>
                   return toString (← fvarId.getUserName)
-              let (mvars, consts) ← getMVarsAndConstantsNoDelayed t
-              let usedGoals : Array Json ← mvars.mapM fun mvarId => do
-                let new := !info.mctxBefore.decls.contains mvarId
-                let index? := info.goalsAfter.idxOf? mvarId
-                let kind ← mvarId.getKind
-                let pp ← Meta.ppGoal mvarId
-                return json% {
-                  new : $new,
-                  index : $index?,
-                  kind : $(toString kind),
-                  pp : $(toString pp)
-                }
+              let (usedGoals, consts) ← if !assigned then pure (#[], {}) else
+                let (mvars, consts) ← getMVarsAndConstantsNoDelayed t
+                let usedGoals ← mvars.mapM fun mvarId => do
+                  let new := !info.mctxBefore.decls.contains mvarId
+                  let index? := info.goalsAfter.idxOf? mvarId
+                  let kind ← mvarId.getKind
+                  let pp ← Meta.ppGoal mvarId
+                  return json% {
+                    new : $new,
+                    index : $index?,
+                    kind : $(toString kind),
+                    pp : $(toString pp)
+                  }
+                pure (usedGoals, consts)
               return (assigned, consts, fvars, usedGoals)
           return json% {
             pp : $(toString pp),

--- a/LeanScout/DataExtractors/Tactics.lean
+++ b/LeanScout/DataExtractors/Tactics.lean
@@ -33,7 +33,7 @@ private partial def collectMVarsAndUsedConstants (e : Expr) (consts : NameSet) :
 
 /-- Gets the unassigned metavariables in `e` after following delayed assignments, as well as the
 constants encountered along the way. Does not include the intermediate delayed-assigned mvars. -/
-def getMVarsAndConstantsNoDelayed (e : Expr) : MetaM (Array MVarId × NameSet) := do
+private def getMVarsAndConstantsNoDelayed (e : Expr) : MetaM (Array MVarId × NameSet) := do
   let (consts, { result .. }) ← collectMVarsAndUsedConstants e {} |>.run {}
   let result ← result.filterM (notM ·.isDelayedAssigned)
   return (result, consts)

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ filtered = dataset.filter(lambda x: x["allowCompletion"])
 ```
 
 ### `tactics`
-Extracts tactic invocations with before/after goal states, used constants, used free variables, elaborator info, syntax kinds, and source locations.
+Extracts tactic invocations with before/after goal states, used constants, used free variables, used goals, elaborator info, syntax kinds, and source locations.
 
 **Supported modes**: `--read`, `--library`
 
@@ -282,8 +282,13 @@ lake run scout --command tactics --parquet --parallel 4 --library LeanScoutTest
 - `goals` (list): List of goal states before the tactic
   - `pp` (string): Pretty-printed goal
   - `assigned` (bool): Whether the original goal metavariable is assigned after elaborating the tactic
-  - `usedConstants` (list of strings): Constants referenced in the instantiated goal
+  - `usedConstants` (list of strings): Constants referenced in the instantiated goal, including through delayed-assigned metavariables
   - `usedFVars` (list of strings): Free variables referenced in the instantiated goal, using the same sanitized names as the pretty-printed goal
+  - `usedGoals` (list): Goals/metavariables referenced in the instantiated goal after following delayed assignments
+    - `new` (bool): Whether the used goal was created by this tactic rather than present before elaborating it
+    - `index` (nat, nullable): Index of the used goal in `goalsAfter`, or `null` if it is not present there
+    - `kind` (string): Metavariable kind (`natural`, `synthetic`, or `syntheticOpaque`)
+    - `pp` (string): Pretty-printed used goal
 - `goalsAfter` (list of strings): Pretty-printed goal states after the tactic
 - `ppTac` (string): Pretty-printed tactic syntax
 - `elaborator` (string): Name of the elaborator that produced this tactic

--- a/test/extractors/test_tactics.py
+++ b/test/extractors/test_tactics.py
@@ -61,6 +61,36 @@ def position_tuple(pos: dict[str, Any]) -> tuple[int, int]:
     return (pos["line"], pos["column"])
 
 
+def assert_used_goal_dict(used_goal: dict[str, Any], tactic: str):
+    assert 'new' in used_goal, f"Used goal missing 'new' for tactic {tactic}"
+    assert 'index' in used_goal, f"Used goal missing 'index' for tactic {tactic}"
+    assert 'kind' in used_goal, f"Used goal missing 'kind' for tactic {tactic}"
+    assert 'pp' in used_goal, f"Used goal missing 'pp' for tactic {tactic}"
+
+    assert isinstance(used_goal['new'], bool), f"Used goal 'new' should be bool for tactic {tactic}"
+    assert used_goal['index'] is None or isinstance(used_goal['index'], int), (
+        f"Used goal 'index' should be int or None for tactic {tactic}"
+    )
+    assert isinstance(used_goal['kind'], str), f"Used goal 'kind' should be string for tactic {tactic}"
+    assert isinstance(used_goal['pp'], str), f"Used goal 'pp' should be string for tactic {tactic}"
+
+
+def assert_goal_dict(goal: dict[str, Any], tactic: str):
+    assert 'pp' in goal, f"Goal missing 'pp' for tactic {tactic}"
+    assert 'assigned' in goal, f"Goal missing 'assigned' for tactic {tactic}"
+    assert 'usedConstants' in goal, f"Goal missing 'usedConstants' for tactic {tactic}"
+    assert 'usedFVars' in goal, f"Goal missing 'usedFVars' for tactic {tactic}"
+    assert 'usedGoals' in goal, f"Goal missing 'usedGoals' for tactic {tactic}"
+
+    assert isinstance(goal['pp'], str), f"Goal 'pp' should be string for tactic {tactic}"
+    assert isinstance(goal['assigned'], bool), f"Goal 'assigned' should be bool for tactic {tactic}"
+    assert isinstance(goal['usedConstants'], list), f"Goal 'usedConstants' should be list for tactic {tactic}"
+    assert isinstance(goal['usedFVars'], list), f"Goal 'usedFVars' should be list for tactic {tactic}"
+    assert isinstance(goal['usedGoals'], list), f"Goal 'usedGoals' should be list for tactic {tactic}"
+    for used_goal in goal['usedGoals']:
+        assert_used_goal_dict(used_goal, tactic)
+
+
 @pytest.fixture(scope="module")
 def tactics_dataset():
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -216,15 +246,7 @@ def test_tactics_goal_structure(tactics_dataset):
 
         if len(record['goals']) > 0:
             for goal in record['goals']:
-                assert 'pp' in goal, f"Goal missing 'pp' for tactic {record['ppTac']}"
-                assert 'assigned' in goal, f"Goal missing 'assigned' for tactic {record['ppTac']}"
-                assert 'usedConstants' in goal, f"Goal missing 'usedConstants' for tactic {record['ppTac']}"
-                assert 'usedFVars' in goal, f"Goal missing 'usedFVars' for tactic {record['ppTac']}"
-
-                assert isinstance(goal['pp'], str), f"Goal 'pp' should be string for tactic {record['ppTac']}"
-                assert isinstance(goal['assigned'], bool), f"Goal 'assigned' should be bool for tactic {record['ppTac']}"
-                assert isinstance(goal['usedConstants'], list), f"Goal 'usedConstants' should be list for tactic {record['ppTac']}"
-                assert isinstance(goal['usedFVars'], list), f"Goal 'usedFVars' should be list for tactic {record['ppTac']}"
+                assert_goal_dict(goal, record['ppTac'])
 
 
 def test_tactics_elaborator_field(tactics_dataset):
@@ -310,6 +332,49 @@ def test_tactics_goals_after_and_dependency_fields(tactics_dataset):
     assert constructor_goal["assigned"] is True
     assert "And.intro" in constructor_goal["usedConstants"]
     assert constructor_goal["usedFVars"] == ["p"]
+    assert constructor_goal["usedGoals"] == [
+        {
+            "index": 0,
+            "kind": "natural",
+            "new": True,
+            "pp": "case left\np : Prop\nhp : p\n⊢ p",
+        },
+        {
+            "index": 1,
+            "kind": "natural",
+            "new": True,
+            "pp": "case right\np : Prop\nhp : p\n⊢ p",
+        },
+    ]
+
+
+def test_tactics_used_goals_refine_fixture(tactics_dataset):
+    refine_records = get_records_by_tactic(tactics_dataset, "refine ⟨?n, ?h⟩")
+    assert len(refine_records) == 1, "Expected refine tactic from usedGoals fixture"
+    refine = refine_records[0]
+    assert refine["goalsAfter"] == [
+        "case n\nP : Nat → Prop\nh : P 0\n⊢ Nat",
+        "case h\nP : Nat → Prop\nh : P 0\n⊢ P ?n",
+    ]
+
+    refine_goal = refine["goals"][0]
+    assert refine_goal["assigned"] is True
+    assert "Exists.intro" in refine_goal["usedConstants"]
+    assert refine_goal["usedFVars"] == ["P"]
+    assert refine_goal["usedGoals"] == [
+        {
+            "index": 0,
+            "kind": "syntheticOpaque",
+            "new": True,
+            "pp": "case n\nP : Nat → Prop\nh : P 0\n⊢ Nat",
+        },
+        {
+            "index": 1,
+            "kind": "syntheticOpaque",
+            "new": True,
+            "pp": "case h\nP : Nat → Prop\nh : P 0\n⊢ P ?n",
+        },
+    ]
 
 
 def test_tactics_rfl_from_test_project(tactics_dataset):
@@ -369,7 +434,10 @@ def test_tactics_jsonl_output_format(tactics_jsonl_records):
         assert_position_dict(record["startPos"])
         assert_position_dict(record["endPos"])
         assert_position_dict(record["nextStartPos"])
+        assert isinstance(record["goals"], list), "goals should be a list"
         assert isinstance(record["goalsAfter"], list), "goalsAfter should be a list"
+        for goal in record["goals"]:
+            assert_goal_dict(goal, record["ppTac"])
         assert position_tuple(record["startPos"]) <= position_tuple(record["endPos"]), (
             f"Expected startPos <= endPos for tactic {record['ppTac']}, got {record['startPos']} -> {record['endPos']}"
         )
@@ -406,6 +474,33 @@ def test_tactics_jsonl_known_source_spans(tactics_jsonl_records):
     assert succ_spans == {
         ("LeanScoutTestProject.Basic", (17, 4), (17, 39), (19, 0))
     }
+
+
+def test_tactics_jsonl_used_goals_refine_fixture(tactics_jsonl_records):
+    refine_records = [
+        record for record in tactics_jsonl_records
+        if record["ppTac"] == "refine ⟨?n, ?h⟩"
+    ]
+    assert len(refine_records) == 1, "Expected refine tactic from usedGoals fixture"
+    refine = refine_records[0]
+    assert refine["goalsAfter"] == [
+        "case n\nP : Nat → Prop\nh : P 0\n⊢ Nat",
+        "case h\nP : Nat → Prop\nh : P 0\n⊢ P ?n",
+    ]
+    assert refine["goals"][0]["usedGoals"] == [
+        {
+            "new": True,
+            "index": 0,
+            "kind": "syntheticOpaque",
+            "pp": "case n\nP : Nat → Prop\nh : P 0\n⊢ Nat",
+        },
+        {
+            "new": True,
+            "index": 1,
+            "kind": "syntheticOpaque",
+            "pp": "case h\nP : Nat → Prop\nh : P 0\n⊢ P ?n",
+        },
+    ]
 
 
 def test_tactics_jsonl_has_expected_tactics(tactics_jsonl_records):

--- a/test_project/LeanScoutTestProject/Basic.lean
+++ b/test_project/LeanScoutTestProject/Basic.lean
@@ -21,3 +21,8 @@ theorem tactic_goals_after_fixture (p : Prop) : p → p ∧ p := by
   constructor
   · exact hp
   · exact hp
+
+theorem tactic_used_goals_fixture (P : Nat → Prop) (h : P 0) : ∃ n, P n := by
+  refine ⟨?n, ?h⟩
+  · exact 0
+  · exact h


### PR DESCRIPTION
This PR makes `tactics` record, for each goal, the mvars used in its assignment. Specifically, it records
1. whether the used goal is new
2. its index in the `goalsAfter` list, or `null` if it does not appear in the goal list
3. its `MetavarKind`
4. the pretty-printed version of it

For example, after a `refine fun _ => ⟨?_, ?n⟩`,
```json
"usedGoals": [
  {
    "index": 0,
    "kind": "syntheticOpaque",
    "new": true,
    "pp": "P : Nat → Prop\nh : P 0\nx✝ : Bool\n⊢ Nat"
  },
  {
    "index": 1,
    "kind": "syntheticOpaque",
    "new": true,
    "pp": "case n\nP : Nat → Prop\nh : P 0\nx✝ : Bool\n⊢ P ?m.9"
  }
  ]
```

It also fixes the collection of used constants to see through delayed-assigned metavariables.

There are a couple optimizations we could use if compressing data is important: the `MetavarKind` could be encoded as a `Nat` instead of a human-readable string, and we could only pretty-print goals which do not also appear pretty-printed in `goalsAfter`.

---

- [x] depends on: #47