### PR TITLE
feat(`tactics`): `ppTerm` for goals

### DIFF
--- a/LeanScout/DataExtractors/Tactics.lean
+++ b/LeanScout/DataExtractors/Tactics.lean
@@ -4,10 +4,9 @@ public import LeanScout.Frontend
 public import LeanScout.InfoTree
 public import LeanScout.Init
 
-open Lean
+open Lean Meta
 
-namespace LeanScout
-namespace DataExtractors
+namespace LeanScout.DataExtractors
 
 private def positionType : DataType :=
   .struct [
@@ -19,12 +18,28 @@ private def getModuleName? (ctxInfo : Lean.Elab.ContextInfo) : Option String :=
   let moduleName := ctxInfo.env.header.mainModule
   if moduleName == .anonymous then none else some s!"{moduleName}"
 
-private def getSyntaxRange (ctxInfo : Lean.Elab.ContextInfo) (stx : Syntax) : IO (Lean.Position × Lean.Position) := do
+private structure PositionRangeWithNext where
+  startPos : Position
+  endPos : Position
+  /-- Computed by looking at where the trailing whitespace ends. Does not imply that there is a
+  next tactic; this is merely the start position of whatever syntax comes next (possibly the end of
+  the file). -/
+  nextStartPos : Position
+
+private def getSyntaxRange (ctxInfo : Lean.Elab.ContextInfo) (stx : Syntax) :
+    IO PositionRangeWithNext := do
   let some startPos := stx.getPos?
     | throw <| IO.userError s!"Original tactic syntax missing start position for '{stx.getKind}'"
   let some endPos := stx.getTailPos?
     | throw <| IO.userError s!"Original tactic syntax missing end position for '{stx.getKind}'"
-  return (ctxInfo.fileMap.toPosition startPos, ctxInfo.fileMap.toPosition endPos)
+  let some nextStartPos := stx.getTrailingTailPos?
+    | throw <| IO.userError s!"Original tactic syntax missing end position after trailing \
+      whitespace for '{stx.getKind}'"
+  return {
+    startPos := ctxInfo.fileMap.toPosition startPos,
+    endPos := ctxInfo.fileMap.toPosition endPos,
+    nextStartPos := ctxInfo.fileMap.toPosition nextStartPos
+  }
 
 @[data_extractor tactics]
 public unsafe def tactics : DataExtractor where
@@ -32,6 +47,7 @@ public unsafe def tactics : DataExtractor where
     { name := "module", type := .string },
     { name := "startPos", nullable := false, type := positionType },
     { name := "endPos", nullable := false, type := positionType },
+    { name := "nextStartPos", nullable := false, type := positionType },
     { name := "goals", nullable := false, type := .list <| .struct [
       { name := "pp", nullable := false, type := .string },
       { name := "usedConstants", nullable := false, type := .list .string }
@@ -53,7 +69,7 @@ public unsafe def tactics : DataExtractor where
         let ppTac : String := toString info.stx.prettyPrint
         let elaborator := info.elaborator
         let moduleName? := getModuleName? ctxInfo
-        let (startPos, endPos) ← getSyntaxRange ctxInfo info.stx
+        let { startPos, endPos, nextStartPos } ← getSyntaxRange ctxInfo info.stx
         -- `goalsBefore` must be pretty-printed using `mctxBefore`, but the corresponding
         -- metavariables may only be instantiable using assignments from `mctxAfter`.
         let ctxBefore : Lean.Elab.ContextInfo := { ctxInfo with mctx := info.mctxBefore }
@@ -72,14 +88,14 @@ public unsafe def tactics : DataExtractor where
             usedConstants : $(consts.toList.map fun nm => s!"{nm}")
           }
         sink <| json% {
-          module : $(moduleName?),
-          startPos : $(startPos),
-          endPos : $(endPos),
-          goals : $(goals),
-          ppTac : $(ppTac),
-          elaborator : $(elaborator),
-          kind : $(kind)
+          module : $moduleName?,
+          startPos : $startPos,
+          endPos : $endPos,
+          nextStartPos : $nextStartPos,
+          goals : $goals,
+          ppTac : $ppTac,
+          elaborator : $elaborator,
+          kind : $kind
         }
 
-end DataExtractors
-end LeanScout
+end LeanScout.DataExtractors

--- a/LeanScout/DataExtractors/Tactics.lean
+++ b/LeanScout/DataExtractors/Tactics.lean
@@ -32,7 +32,7 @@ private partial def collectMVarsAndUsedConstants (e : Expr) (consts : NameSet) :
   return consts
 
 /-- Gets the unassigned metavariables in `e` after following delayed assignments, as well as the
-constants encountered along the way. -/
+constants encountered along the way. Does not include the intermediate delayed-assigned mvars. -/
 def getMVarsAndConstantsNoDelayed (e : Expr) : MetaM (Array MVarId × NameSet) := do
   let (consts, { result .. }) ← collectMVarsAndUsedConstants e {} |>.run {}
   let result ← result.filterM (notM ·.isDelayedAssigned)

--- a/LeanScout/DataExtractors/Tactics.lean
+++ b/LeanScout/DataExtractors/Tactics.lean
@@ -52,6 +52,7 @@ public unsafe def tactics : DataExtractor where
       { name := "pp", nullable := false, type := .string },
       { name := "usedConstants", nullable := false, type := .list .string }
     ]},
+    { name := "goalsAfter", nullable := false, type := .list .string },
     { name := "ppTac", nullable := false, type := .string },
     { name := "elaborator", nullable := false, type := .string },
     { name := "kind", nullable := false, type := .string },
@@ -87,12 +88,15 @@ public unsafe def tactics : DataExtractor where
             pp : $(toString goal),
             usedConstants : $(consts.toList.map fun nm => s!"{nm}")
           }
+        let goalsAfter : List String ← ctxAfter.runMetaM' {} do
+          info.goalsAfter.mapM fun mvarId => return toString (← Meta.ppGoal mvarId)
         sink <| json% {
           module : $moduleName?,
           startPos : $startPos,
           endPos : $endPos,
           nextStartPos : $nextStartPos,
           goals : $goals,
+          goalsAfter : $goalsAfter,
           ppTac : $ppTac,
           elaborator : $elaborator,
           kind : $kind

--- a/LeanScout/DataExtractors/Tactics.lean
+++ b/LeanScout/DataExtractors/Tactics.lean
@@ -22,8 +22,7 @@ private structure PositionRangeWithNext where
   startPos : Position
   endPos : Position
   /-- Computed by looking at where the trailing whitespace ends. Does not imply that there is a
-  next tactic; this is merely the start position of whatever syntax comes next (possibly the end of
-  the file). -/
+  next tactic; this is merely the start position of whatever syntax comes next (possibly a command, tactic combinator, or even the end of the file). -/
   nextStartPos : Position
 
 private def getSyntaxRange (ctxInfo : Lean.Elab.ContextInfo) (stx : Syntax) :

--- a/LeanScout/DataExtractors/Tactics.lean
+++ b/LeanScout/DataExtractors/Tactics.lean
@@ -50,7 +50,9 @@ public unsafe def tactics : DataExtractor where
     { name := "nextStartPos", nullable := false, type := positionType },
     { name := "goals", nullable := false, type := .list <| .struct [
       { name := "pp", nullable := false, type := .string },
-      { name := "usedConstants", nullable := false, type := .list .string }
+      { name := "assigned", nullable := false, type := .bool },
+      { name := "usedConstants", nullable := false, type := .list .string },
+      { name := "usedFVars", nullable := false, type := .list .string },
     ]},
     { name := "goalsAfter", nullable := false, type := .list .string },
     { name := "ppTac", nullable := false, type := .string },
@@ -73,20 +75,27 @@ public unsafe def tactics : DataExtractor where
         let { startPos, endPos, nextStartPos } ← getSyntaxRange ctxInfo info.stx
         -- `goalsBefore` must be pretty-printed using `mctxBefore`, but the corresponding
         -- metavariables may only be instantiable using assignments from `mctxAfter`.
-        let ctxBefore : Lean.Elab.ContextInfo := { ctxInfo with mctx := info.mctxBefore }
-        let ctxAfter : Lean.Elab.ContextInfo := { ctxInfo with mctx := info.mctxAfter }
+        let ctxBefore : Elab.ContextInfo := { ctxInfo with mctx := info.mctxBefore }
+        let ctxAfter : Elab.ContextInfo := { ctxInfo with mctx := info.mctxAfter }
         let goals : List Json ← info.goalsBefore.mapM fun mvarId => do
-          let mvarDecl := info.mctxBefore.getDecl mvarId
-          let goal ← ctxBefore.runMetaM' {} do
-            Lean.Meta.withLCtx mvarDecl.lctx mvarDecl.localInstances do
-              Lean.Meta.ppGoal mvarId
-          let consts ← ctxAfter.runMetaM' {} do
-            Lean.Meta.withLCtx mvarDecl.lctx mvarDecl.localInstances do
-              let t ← Lean.instantiateMVars <| .mvar mvarId
-              return t.getUsedConstantsAsSet
+          let goal ← ctxBefore.runMetaM' {} do Meta.ppGoal mvarId
+          let (assigned, consts, fvars) ← ctxAfter.runMetaM' {} do
+            mvarId.withContext do
+              -- sufficient; user-facing goals will not be delayed-assigned
+              let assigned ← mvarId.isAssigned
+              let t ← instantiateMVars <| .mvar mvarId
+              let (_, { fvarIds .. }) ← t.collectFVars.run {}
+              -- Sanitize the names so their string representations are the same as in `ppGoal`.
+              let fvars ← if fvarIds.isEmpty then pure #[] else
+                let sanitizedLCtx := (← getLCtx).sanitizeNames.run' { options := (← getOptions) }
+                withLCtx' sanitizedLCtx do fvarIds.mapM fun fvarId =>
+                  return toString (← fvarId.getUserName)
+              return (assigned, t.getUsedConstantsAsSet, fvars)
           return json% {
             pp : $(toString goal),
-            usedConstants : $(consts.toList.map fun nm => s!"{nm}")
+            assigned : $assigned,
+            usedConstants : $(consts.toList.map fun nm => s!"{nm}"),
+            usedFVars : $fvars
           }
         let goalsAfter : List String ← ctxAfter.runMetaM' {} do
           info.goalsAfter.mapM fun mvarId => return toString (← Meta.ppGoal mvarId)

--- a/LeanScout/DataExtractors/Tactics.lean
+++ b/LeanScout/DataExtractors/Tactics.lean
@@ -77,7 +77,7 @@ public unsafe def tactics : DataExtractor where
         let ctxBefore : Elab.ContextInfo := { ctxInfo with mctx := info.mctxBefore }
         let ctxAfter : Elab.ContextInfo := { ctxInfo with mctx := info.mctxAfter }
         let goals : List Json ← info.goalsBefore.mapM fun mvarId => do
-          let goal ← ctxBefore.runMetaM' {} do Meta.ppGoal mvarId
+          let pp ← ctxBefore.runMetaM' {} do Meta.ppGoal mvarId
           let mvarDeclBefore := info.mctxBefore.getDecl mvarId
           let (assigned, consts, fvars) ← ctxAfter.runMetaM' {} do
             -- Use earlier context in case there was in-place modification of the local context
@@ -93,7 +93,7 @@ public unsafe def tactics : DataExtractor where
                   return toString (← fvarId.getUserName)
               return (assigned, t.getUsedConstantsAsSet, fvars)
           return json% {
-            pp : $(toString goal),
+            pp : $(toString pp),
             assigned : $assigned,
             usedConstants : $(consts.toList.map fun nm => s!"{nm}"),
             usedFVars : $fvars

--- a/LeanScout/DataExtractors/Tactics.lean
+++ b/LeanScout/DataExtractors/Tactics.lean
@@ -78,8 +78,10 @@ public unsafe def tactics : DataExtractor where
         let ctxAfter : Elab.ContextInfo := { ctxInfo with mctx := info.mctxAfter }
         let goals : List Json ← info.goalsBefore.mapM fun mvarId => do
           let goal ← ctxBefore.runMetaM' {} do Meta.ppGoal mvarId
+          let mvarDeclBefore := info.mctxBefore.getDecl mvarId
           let (assigned, consts, fvars) ← ctxAfter.runMetaM' {} do
-            mvarId.withContext do
+            -- Use earlier context in case there was in-place modification of the local context
+            withLCtx mvarDeclBefore.lctx mvarDeclBefore.localInstances do
               -- sufficient; user-facing goals will not be delayed-assigned
               let assigned ← mvarId.isAssigned
               let t ← instantiateMVars <| .mvar mvarId

--- a/LeanScout/DataExtractors/Tactics.lean
+++ b/LeanScout/DataExtractors/Tactics.lean
@@ -14,6 +14,30 @@ private def positionType : DataType :=
     { name := "column", nullable := false, type := .nat }
   ]
 
+/--
+Like `Meta.collectMVars`, but also collects used constants after following delayed assignments.
+-/
+private partial def collectMVarsAndUsedConstants (e : Expr) (consts : NameSet) :
+    StateRefT CollectMVars.State MetaM NameSet := do
+  let e ← instantiateMVars e
+  let s ← get
+  let resultSavedSize := s.result.size
+  let mut consts := e.getUsedConstantsAsSet ∪ consts
+  let s := e.collectMVars s
+  set s
+  for mvarId in s.result[resultSavedSize...*] do
+    match (← getDelayedMVarAssignment? mvarId) with
+    | none   => pure ()
+    | some d => consts ← collectMVarsAndUsedConstants (.mvar d.mvarIdPending) consts
+  return consts
+
+/-- Gets the unassigned metavariables in `e` after following delayed assignments, as well as the
+constants encountered along the way. -/
+def getMVarsAndConstantsNoDelayed (e : Expr) : MetaM (Array MVarId × NameSet) := do
+  let (consts, { result .. }) ← collectMVarsAndUsedConstants e {} |>.run {}
+  let result ← result.filterM (notM ·.isDelayedAssigned)
+  return (result, consts)
+
 private def getModuleName? (ctxInfo : Lean.Elab.ContextInfo) : Option String :=
   let moduleName := ctxInfo.env.header.mainModule
   if moduleName == .anonymous then none else some s!"{moduleName}"
@@ -40,6 +64,12 @@ private def getSyntaxRange (ctxInfo : Lean.Elab.ContextInfo) (stx : Syntax) :
     nextStartPos := ctxInfo.fileMap.toPosition nextStartPos
   }
 
+local instance : ToString MetavarKind where
+  toString
+    | .natural => "natural"
+    | .synthetic => "synthetic"
+    | .syntheticOpaque => "syntheticOpaque"
+
 @[data_extractor tactics]
 public unsafe def tactics : DataExtractor where
   schema := .mk [
@@ -52,6 +82,12 @@ public unsafe def tactics : DataExtractor where
       { name := "assigned", nullable := false, type := .bool },
       { name := "usedConstants", nullable := false, type := .list .string },
       { name := "usedFVars", nullable := false, type := .list .string },
+      { name := "usedGoals", nullable := false, type := .list <| .struct [
+        { name := "new", nullable := false, type := .bool },
+        { name := "index", nullable := true, type := .nat }, -- null ↔ does not appear in goal list
+        { name := "kind", nullable := false, type := .string },
+        { name := "pp", nullable := false, type := .string }
+      ]}
     ]},
     { name := "goalsAfter", nullable := false, type := .list .string },
     { name := "ppTac", nullable := false, type := .string },
@@ -79,7 +115,7 @@ public unsafe def tactics : DataExtractor where
         let goals : List Json ← info.goalsBefore.mapM fun mvarId => do
           let pp ← ctxBefore.runMetaM' {} do Meta.ppGoal mvarId
           let mvarDeclBefore := info.mctxBefore.getDecl mvarId
-          let (assigned, consts, fvars) ← ctxAfter.runMetaM' {} do
+          let (assigned, consts, fvars, usedGoals) ← ctxAfter.runMetaM' {} do
             -- Use earlier context in case there was in-place modification of the local context
             withLCtx mvarDeclBefore.lctx mvarDeclBefore.localInstances do
               -- sufficient; user-facing goals will not be delayed-assigned
@@ -91,12 +127,25 @@ public unsafe def tactics : DataExtractor where
                 let sanitizedLCtx := (← getLCtx).sanitizeNames.run' { options := (← getOptions) }
                 withLCtx' sanitizedLCtx do fvarIds.mapM fun fvarId =>
                   return toString (← fvarId.getUserName)
-              return (assigned, t.getUsedConstantsAsSet, fvars)
+              let (mvars, consts) ← getMVarsAndConstantsNoDelayed t
+              let usedGoals : Array Json ← mvars.mapM fun mvarId => do
+                let new := !info.mctxBefore.decls.contains mvarId
+                let index? := info.goalsAfter.idxOf? mvarId
+                let kind ← mvarId.getKind
+                let pp ← Meta.ppGoal mvarId
+                return json% {
+                  new : $new,
+                  index : $index?,
+                  kind : $(toString kind),
+                  pp : $(toString pp)
+                }
+              return (assigned, consts, fvars, usedGoals)
           return json% {
             pp : $(toString pp),
             assigned : $assigned,
             usedConstants : $(consts.toList.map fun nm => s!"{nm}"),
-            usedFVars : $fvars
+            usedFVars : $fvars,
+            usedGoals : $usedGoals
           }
         let goalsAfter : List String ← ctxAfter.runMetaM' {} do
           info.goalsAfter.mapM fun mvarId => return toString (← Meta.ppGoal mvarId)

--- a/LeanScout/DataExtractors/Tactics.lean
+++ b/LeanScout/DataExtractors/Tactics.lean
@@ -79,6 +79,7 @@ public unsafe def tactics : DataExtractor where
     { name := "nextStartPos", nullable := false, type := positionType },
     { name := "goals", nullable := false, type := .list <| .struct [
       { name := "pp", nullable := false, type := .string },
+      { name := "ppTerm", nullable := false, type := .string },
       { name := "assigned", nullable := false, type := .bool },
       { name := "usedConstants", nullable := false, type := .list .string },
       { name := "usedFVars", nullable := false, type := .list .string },
@@ -86,7 +87,8 @@ public unsafe def tactics : DataExtractor where
         { name := "new", nullable := false, type := .bool },
         { name := "index", nullable := true, type := .nat }, -- null ↔ does not appear in goal list
         { name := "kind", nullable := false, type := .string },
-        { name := "pp", nullable := false, type := .string }
+        { name := "pp", nullable := false, type := .string },
+        { name := "ppTerm", nullable := false, type := .string }
       ]}
     ]},
     { name := "goalsAfter", nullable := false, type := .list .string },
@@ -115,7 +117,7 @@ public unsafe def tactics : DataExtractor where
         let goals : List Json ← info.goalsBefore.mapM fun mvarId => do
           let pp ← ctxBefore.runMetaM' {} do Meta.ppGoal mvarId
           let mvarDeclBefore := info.mctxBefore.getDecl mvarId
-          let (assigned, consts, fvars, usedGoals) ← ctxAfter.runMetaM' {} do
+          let (assigned, consts, fvars, usedGoals, ppTerm) ← ctxAfter.runMetaM' {} do
             -- Use earlier context in case there was in-place modification of the local context
             withLCtx mvarDeclBefore.lctx mvarDeclBefore.localInstances do
               -- sufficient; user-facing goals will not be delayed-assigned
@@ -138,12 +140,14 @@ public unsafe def tactics : DataExtractor where
                     new : $new,
                     index : $index?,
                     kind : $(toString kind),
-                    pp : $(toString pp)
+                    pp : $(toString pp),
+                    ppTerm : $(toString <|← ppExpr (.mvar mvarId))
                   }
                 pure (usedGoals, consts)
-              return (assigned, consts, fvars, usedGoals)
+              return (assigned, consts, fvars, usedGoals, ← ppExpr (.mvar mvarId))
           return json% {
             pp : $(toString pp),
+            ppTerm : $(toString ppTerm),
             assigned : $assigned,
             usedConstants : $(consts.toList.map fun nm => s!"{nm}"),
             usedFVars : $fvars,

--- a/LeanScout/DataExtractors/Tactics.lean
+++ b/LeanScout/DataExtractors/Tactics.lean
@@ -127,18 +127,20 @@ public unsafe def tactics : DataExtractor where
                 let sanitizedLCtx := (← getLCtx).sanitizeNames.run' { options := (← getOptions) }
                 withLCtx' sanitizedLCtx do fvarIds.mapM fun fvarId =>
                   return toString (← fvarId.getUserName)
-              let (mvars, consts) ← getMVarsAndConstantsNoDelayed t
-              let usedGoals : Array Json ← mvars.mapM fun mvarId => do
-                let new := !info.mctxBefore.decls.contains mvarId
-                let index? := info.goalsAfter.idxOf? mvarId
-                let kind ← mvarId.getKind
-                let pp ← Meta.ppGoal mvarId
-                return json% {
-                  new : $new,
-                  index : $index?,
-                  kind : $(toString kind),
-                  pp : $(toString pp)
-                }
+              let (usedGoals, consts) ← if !assigned then pure (#[], {}) else
+                let (mvars, consts) ← getMVarsAndConstantsNoDelayed t
+                let usedGoals ← mvars.mapM fun mvarId => do
+                  let new := !info.mctxBefore.decls.contains mvarId
+                  let index? := info.goalsAfter.idxOf? mvarId
+                  let kind ← mvarId.getKind
+                  let pp ← Meta.ppGoal mvarId
+                  return json% {
+                    new : $new,
+                    index : $index?,
+                    kind : $(toString kind),
+                    pp : $(toString pp)
+                  }
+                pure (usedGoals, consts)
               return (assigned, consts, fvars, usedGoals)
           return json% {
             pp : $(toString pp),

--- a/LeanScout/DataExtractors/Tactics.lean
+++ b/LeanScout/DataExtractors/Tactics.lean
@@ -115,9 +115,10 @@ public unsafe def tactics : DataExtractor where
         let ctxBefore : Elab.ContextInfo := { ctxInfo with mctx := info.mctxBefore }
         let ctxAfter : Elab.ContextInfo := { ctxInfo with mctx := info.mctxAfter }
         let goals : List Json ← info.goalsBefore.mapM fun mvarId => do
-          let pp ← ctxBefore.runMetaM' {} do Meta.ppGoal mvarId
+          let (pp, ppTerm) ← ctxBefore.runMetaM' {} do
+            return (← Meta.ppGoal mvarId, ← ppExpr (.mvar mvarId))
           let mvarDeclBefore := info.mctxBefore.getDecl mvarId
-          let (assigned, consts, fvars, usedGoals, ppTerm) ← ctxAfter.runMetaM' {} do
+          let (assigned, consts, fvars, usedGoals) ← ctxAfter.runMetaM' {} do
             -- Use earlier context in case there was in-place modification of the local context
             withLCtx mvarDeclBefore.lctx mvarDeclBefore.localInstances do
               -- sufficient; user-facing goals will not be delayed-assigned
@@ -144,7 +145,7 @@ public unsafe def tactics : DataExtractor where
                     ppTerm : $(toString <|← ppExpr (.mvar mvarId))
                   }
                 pure (usedGoals, consts)
-              return (assigned, consts, fvars, usedGoals, ← ppExpr (.mvar mvarId))
+              return (assigned, consts, fvars, usedGoals)
           return json% {
             pp : $(toString pp),
             ppTerm : $(toString ppTerm),

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ lake run scout --command tactics --parquet --parallel 4 --library LeanScoutTest
   - `column` (nat): 0-based column number
 - `goals` (list): List of goal states before the tactic
   - `pp` (string): Pretty-printed goal
-  - `ppTerm` (string): Pretty-printed term representation of the instantiated goal metavariable
+  - `ppTerm` (string): Pretty-printed term representation of the original goal metavariable before elaborating the tactic
   - `assigned` (bool): Whether the original goal metavariable is assigned after elaborating the tactic
   - `usedConstants` (list of strings): Constants referenced in the instantiated goal, including through delayed-assigned metavariables
   - `usedFVars` (list of strings): Free variables referenced in the instantiated goal, using the same sanitized names as the pretty-printed goal

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ filtered = dataset.filter(lambda x: x["allowCompletion"])
 ```
 
 ### `tactics`
-Extracts tactic invocations with before/after goal states, used constants, used free variables, used goals, elaborator info, syntax kinds, and source locations.
+Extracts tactic invocations with before/after goal states, proof-term views of goals, used constants, used free variables, used goals, elaborator info, syntax kinds, and source locations.
 
 **Supported modes**: `--read`, `--library`
 
@@ -281,6 +281,7 @@ lake run scout --command tactics --parquet --parallel 4 --library LeanScoutTest
   - `column` (nat): 0-based column number
 - `goals` (list): List of goal states before the tactic
   - `pp` (string): Pretty-printed goal
+  - `ppTerm` (string): Pretty-printed term representation of the instantiated goal metavariable
   - `assigned` (bool): Whether the original goal metavariable is assigned after elaborating the tactic
   - `usedConstants` (list of strings): Constants referenced in the instantiated goal, including through delayed-assigned metavariables
   - `usedFVars` (list of strings): Free variables referenced in the instantiated goal, using the same sanitized names as the pretty-printed goal
@@ -289,6 +290,7 @@ lake run scout --command tactics --parquet --parallel 4 --library LeanScoutTest
     - `index` (nat, nullable): Index of the used goal in `goalsAfter`, or `null` if it is not present there
     - `kind` (string): Metavariable kind (`natural`, `synthetic`, or `syntheticOpaque`)
     - `pp` (string): Pretty-printed used goal
+    - `ppTerm` (string): Pretty-printed term representation of the used goal metavariable
 - `goalsAfter` (list of strings): Pretty-printed goal states after the tactic
 - `ppTac` (string): Pretty-printed tactic syntax
 - `elaborator` (string): Name of the elaborator that produced this tactic

--- a/test/extractors/test_tactics.py
+++ b/test/extractors/test_tactics.py
@@ -333,7 +333,7 @@ def test_tactics_goals_after_and_dependency_fields(tactics_dataset):
     ]
 
     constructor_goal = constructor["goals"][0]
-    assert constructor_goal["ppTerm"] == "⟨?left, ?right⟩"
+    assert constructor_goal["ppTerm"].startswith("?m.")
     assert constructor_goal["assigned"] is True
     assert "And.intro" in constructor_goal["usedConstants"]
     assert constructor_goal["usedFVars"] == ["p"]
@@ -365,7 +365,7 @@ def test_tactics_used_goals_refine_fixture(tactics_dataset):
     ]
 
     refine_goal = refine["goals"][0]
-    assert refine_goal["ppTerm"] == "Exists.intro ?n ?h"
+    assert refine_goal["ppTerm"].startswith("?m.")
     assert refine_goal["assigned"] is True
     assert "Exists.intro" in refine_goal["usedConstants"]
     assert refine_goal["usedFVars"] == ["P"]

--- a/test/extractors/test_tactics.py
+++ b/test/extractors/test_tactics.py
@@ -66,6 +66,7 @@ def assert_used_goal_dict(used_goal: dict[str, Any], tactic: str):
     assert 'index' in used_goal, f"Used goal missing 'index' for tactic {tactic}"
     assert 'kind' in used_goal, f"Used goal missing 'kind' for tactic {tactic}"
     assert 'pp' in used_goal, f"Used goal missing 'pp' for tactic {tactic}"
+    assert 'ppTerm' in used_goal, f"Used goal missing 'ppTerm' for tactic {tactic}"
 
     assert isinstance(used_goal['new'], bool), f"Used goal 'new' should be bool for tactic {tactic}"
     assert used_goal['index'] is None or isinstance(used_goal['index'], int), (
@@ -73,16 +74,19 @@ def assert_used_goal_dict(used_goal: dict[str, Any], tactic: str):
     )
     assert isinstance(used_goal['kind'], str), f"Used goal 'kind' should be string for tactic {tactic}"
     assert isinstance(used_goal['pp'], str), f"Used goal 'pp' should be string for tactic {tactic}"
+    assert isinstance(used_goal['ppTerm'], str), f"Used goal 'ppTerm' should be string for tactic {tactic}"
 
 
 def assert_goal_dict(goal: dict[str, Any], tactic: str):
     assert 'pp' in goal, f"Goal missing 'pp' for tactic {tactic}"
+    assert 'ppTerm' in goal, f"Goal missing 'ppTerm' for tactic {tactic}"
     assert 'assigned' in goal, f"Goal missing 'assigned' for tactic {tactic}"
     assert 'usedConstants' in goal, f"Goal missing 'usedConstants' for tactic {tactic}"
     assert 'usedFVars' in goal, f"Goal missing 'usedFVars' for tactic {tactic}"
     assert 'usedGoals' in goal, f"Goal missing 'usedGoals' for tactic {tactic}"
 
     assert isinstance(goal['pp'], str), f"Goal 'pp' should be string for tactic {tactic}"
+    assert isinstance(goal['ppTerm'], str), f"Goal 'ppTerm' should be string for tactic {tactic}"
     assert isinstance(goal['assigned'], bool), f"Goal 'assigned' should be bool for tactic {tactic}"
     assert isinstance(goal['usedConstants'], list), f"Goal 'usedConstants' should be list for tactic {tactic}"
     assert isinstance(goal['usedFVars'], list), f"Goal 'usedFVars' should be list for tactic {tactic}"
@@ -329,6 +333,7 @@ def test_tactics_goals_after_and_dependency_fields(tactics_dataset):
     ]
 
     constructor_goal = constructor["goals"][0]
+    assert constructor_goal["ppTerm"] == "⟨?left, ?right⟩"
     assert constructor_goal["assigned"] is True
     assert "And.intro" in constructor_goal["usedConstants"]
     assert constructor_goal["usedFVars"] == ["p"]
@@ -338,12 +343,14 @@ def test_tactics_goals_after_and_dependency_fields(tactics_dataset):
             "kind": "natural",
             "new": True,
             "pp": "case left\np : Prop\nhp : p\n⊢ p",
+            "ppTerm": "?left",
         },
         {
             "index": 1,
             "kind": "natural",
             "new": True,
             "pp": "case right\np : Prop\nhp : p\n⊢ p",
+            "ppTerm": "?right",
         },
     ]
 
@@ -358,6 +365,7 @@ def test_tactics_used_goals_refine_fixture(tactics_dataset):
     ]
 
     refine_goal = refine["goals"][0]
+    assert refine_goal["ppTerm"] == "Exists.intro ?n ?h"
     assert refine_goal["assigned"] is True
     assert "Exists.intro" in refine_goal["usedConstants"]
     assert refine_goal["usedFVars"] == ["P"]
@@ -367,12 +375,14 @@ def test_tactics_used_goals_refine_fixture(tactics_dataset):
             "kind": "syntheticOpaque",
             "new": True,
             "pp": "case n\nP : Nat → Prop\nh : P 0\n⊢ Nat",
+            "ppTerm": "?n",
         },
         {
             "index": 1,
             "kind": "syntheticOpaque",
             "new": True,
             "pp": "case h\nP : Nat → Prop\nh : P 0\n⊢ P ?n",
+            "ppTerm": "?h",
         },
     ]
 
@@ -493,12 +503,14 @@ def test_tactics_jsonl_used_goals_refine_fixture(tactics_jsonl_records):
             "index": 0,
             "kind": "syntheticOpaque",
             "pp": "case n\nP : Nat → Prop\nh : P 0\n⊢ Nat",
+            "ppTerm": "?n",
         },
         {
             "new": True,
             "index": 1,
             "kind": "syntheticOpaque",
             "pp": "case h\nP : Nat → Prop\nh : P 0\n⊢ P ?n",
+            "ppTerm": "?h",
         },
     ]
 


### PR DESCRIPTION
Adds a `ppTerm` field to goals that shows what the goal looks like when pretty-printed in other expressions (e.g. `?m.9`).

---

- [x] depends on: #48