### PR TITLE
feat: include docstrings in types extractor

### DIFF
--- a/LeanScout/DataExtractors/Types.lean
+++ b/LeanScout/DataExtractors/Types.lean
@@ -14,6 +14,7 @@ public unsafe def types : DataExtractor where
     { name := "name", nullable := false, type := .string },
     { name := "module", nullable := true, type := .string },
     { name := "type", nullable := false, type := .string },
+    { name := "docString", nullable := true, type := .string },
     { name := "allowCompletion", nullable := false, type := .bool },
   ]
   key := "name"
@@ -27,10 +28,12 @@ public unsafe def types : DataExtractor where
         | some idx => env.header.moduleNames[idx]!
         | none => if env.constants.map₂.contains n then env.header.mainModule else none
       let allowCompletion := Lean.Meta.allowCompletion env n
+      let docString ← Lean.findDocString? env n
       sink <| json% {
         name : $(n),
         module : $(mod),
         type : $(s!"{← Meta.ppExpr c.type}"),
+        docString : $(docString),
         allowCompletion : $(allowCompletion)
       }
   | _ => throw <| IO.userError "Unsupported Target"

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ lake run scout --command types --parquet --numShards 32 --imports Lean
 We provide three built-in data extractors: `types`, `tactics`, and `const_dep`.
 
 ### `types`
-Extracts constant declarations with their types and modules.
+Extracts constant declarations with their types, modules, and docstrings.
 
 **Supported modes**: `--imports` only
 
@@ -248,6 +248,7 @@ lake run scout --command types --parquet --imports Lean
 - `name` (string): Constant name
 - `module` (string, nullable): Module containing the constant
 - `type` (string): Type signature
+- `docString` (string, nullable): Declaration docstring, if one exists
 - `allowCompletion` (bool): Whether `Lean.Meta.allowCompletion` holds for the constant
 
 **Configuration**:

--- a/test/extractors/test_types.py
+++ b/test/extractors/test_types.py
@@ -95,6 +95,15 @@ def test_types_imports_properties(types_dataset_imports, types_spec):
         if 'type_contains' in props:
             assert_record_contains(actual, 'type', props['type_contains'])
 
+        if 'docString_contains' in props:
+            assert_record_contains(actual, 'docString', props['docString_contains'])
+
+        if 'docString' in props:
+            assert actual['docString'] == props['docString'], (
+                f"docString mismatch for {name}: "
+                f"expected {props['docString']}, got {actual['docString']}"
+            )
+
         if props.get('module_not_null'):
             assert_record_not_null(actual, 'module')
 
@@ -134,11 +143,13 @@ def test_types_imports_schema(types_dataset_imports):
     assert 'name' in first_record
     assert 'module' in first_record
     assert 'type' in first_record
+    assert 'docString' in first_record
     assert 'allowCompletion' in first_record
 
     assert isinstance(first_record['name'], str)
     assert first_record['module'] is None or isinstance(first_record['module'], str)
     assert isinstance(first_record['type'], str)
+    assert first_record['docString'] is None or isinstance(first_record['docString'], str)
     assert isinstance(first_record['allowCompletion'], bool)
 
 
@@ -191,9 +202,11 @@ def test_types_jsonl_output_format(types_jsonl_records):
     for record in types_jsonl_records:
         assert "name" in record, "Record should have 'name' field"
         assert "type" in record, "Record should have 'type' field"
+        assert "docString" in record, "Record should have 'docString' field"
         assert "allowCompletion" in record, "Record should have 'allowCompletion' field"
         assert isinstance(record["name"], str)
         assert isinstance(record["type"], str)
+        assert record["docString"] is None or isinstance(record["docString"], str)
         assert isinstance(record["allowCompletion"], bool)
 
 
@@ -214,6 +227,10 @@ def test_types_jsonl_record_content(types_jsonl_records):
     assert add_zero["module"] == "LeanScoutTestProject.Basic"
     assert "Nat" in add_zero["type"]
     assert add_zero["allowCompletion"] is True
+
+    documented_nat = next((r for r in types_jsonl_records if r["name"] == "documentedNat"), None)
+    assert documented_nat is not None, "Should find documentedNat record"
+    assert "Documented declaration used to test docstring extraction" in documented_nat["docString"]
 
 
 def test_types_known_non_completion_record(types_dataset_imports):

--- a/test/fixtures/types.yaml
+++ b/test/fixtures/types.yaml
@@ -1,7 +1,7 @@
 description: "Test types extractor on LeanScoutTestProject when used as dependency"
 source: "LeanScoutTestProject"
 
-# Exact matches: verify complete record equality for theorems in test project
+# Exact matches: verify selected stable fields for theorems in test project
 exact_matches:
   - name: "add_zero"
     module: "LeanScoutTestProject.Basic"
@@ -43,6 +43,18 @@ property_checks:
       type_contains: "Nat"
       module_not_null: true
       allowCompletion: true
+
+  - name: "documentedNat"
+    properties:
+      module_contains: "LeanScoutTestProject"
+      type_contains: "Nat"
+      docString_contains: "Documented declaration used to test docstring extraction"
+      module_not_null: true
+      allowCompletion: true
+
+  - name: "zero_add"
+    properties:
+      docString: null
 
   - name: "list_nil_append"
     properties:

--- a/test_project/LeanScoutTestProject/Basic.lean
+++ b/test_project/LeanScoutTestProject/Basic.lean
@@ -26,3 +26,6 @@ theorem tactic_used_goals_fixture (P : Nat → Prop) (h : P 0) : ∃ n, P n := b
   refine ⟨?n, ?h⟩
   · exact 0
   · exact h
+
+/-- Documented declaration used to test docstring extraction. -/
+def documentedNat : Nat := 0


### PR DESCRIPTION
## Summary
- add nullable `docString` field to the `types` extractor schema and output
- extract declaration docstrings with `Lean.findDocString?`
- cover docstring presence and absence in extractor tests using an actual documented declaration
- update README schema docs

## Tests
- `lake test`